### PR TITLE
[learn_detail] 학습 상세 페이지 즐겨찾기

### DIFF
--- a/src/components/common/Like.tsx
+++ b/src/components/common/Like.tsx
@@ -1,9 +1,14 @@
 import { icLikeClicked, icLikeHover, icLikeDefault } from 'public/assets/icons';
 import { useState } from 'react';
 import ImageDiv from './ImageDiv';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-function Like() {
+interface LikeProps {
+  fromList: boolean;
+}
+
+function Like(props: LikeProps) {
+  const { fromList } = props;
   const [isLiked, setIsLiked] = useState(false);
 
   return (
@@ -13,13 +18,13 @@ function Like() {
         e.stopPropagation();
         setIsLiked((prev) => !prev);
       }}>
-      <StImageContainer>
+      <StImageContainer fromList={fromList}>
         {isLiked ? (
-          <ImageDiv className="like" src={icLikeClicked} alt="like" />
+          <ImageDiv className="like" src={icLikeClicked} alt="like" layout="fill" />
         ) : (
           <>
-            <ImageDiv className="like" src={icLikeHover} alt="like" />
-            <ImageDiv className="like default" src={icLikeDefault} alt="like" />
+            <ImageDiv className="like" src={icLikeHover} alt="like" layout="fill" />
+            <ImageDiv className="like default" src={icLikeDefault} alt="like" layout="fill" />
           </>
         )}
       </StImageContainer>
@@ -34,25 +39,33 @@ const StLikeButton = styled.button`
   top: 1.2rem;
   right: 1.2rem;
 
-  width: 4rem;
-  height: 4rem;
   padding: 0;
 `;
 
-const StImageContainer = styled.div`
+const StImageContainer = styled.div<{ fromList: boolean }>`
   position: relative;
 
-  .like {
-    position: absolute;
-    top: -2rem;
+  ${({ fromList }) =>
+    fromList
+      ? css`
+          .like {
+            position: absolute;
+            right: 0.2rem;
 
-    opacity: 0;
-  }
+            width: 4rem;
+            height: 4rem;
+            opacity: 0;
+          }
+        `
+      : css`
+          .like {
+            position: absolute;
+            right: 1.2rem;
 
-  .like img {
-    width: 10rem;
-    height: 10rem;
-  }
+            width: 5rem;
+            height: 5rem;
+          }
+        `}
 
   &:hover .default img {
     transition: opacity 1s;

--- a/src/components/common/Like.tsx
+++ b/src/components/common/Like.tsx
@@ -4,11 +4,11 @@ import ImageDiv from './ImageDiv';
 import styled, { css } from 'styled-components';
 
 interface LikeProps {
-  fromList: boolean;
+  isFromList: boolean;
 }
 
 function Like(props: LikeProps) {
-  const { fromList } = props;
+  const { isFromList } = props;
   const [isLiked, setIsLiked] = useState(false);
 
   return (
@@ -18,7 +18,7 @@ function Like(props: LikeProps) {
         e.stopPropagation();
         setIsLiked((prev) => !prev);
       }}>
-      <StImageContainer fromList={fromList}>
+      <StImageContainer isFromList={isFromList}>
         {isLiked ? (
           <ImageDiv className="like" src={icLikeClicked} alt="like" layout="fill" />
         ) : (
@@ -42,11 +42,11 @@ const StLikeButton = styled.button`
   padding: 0;
 `;
 
-const StImageContainer = styled.div<{ fromList: boolean }>`
+const StImageContainer = styled.div<{ isFromList: boolean }>`
   position: relative;
 
-  ${({ fromList }) =>
-    fromList
+  ${({ isFromList }) =>
+    isFromList
       ? css`
           .like {
             position: absolute;

--- a/src/components/common/Like.tsx
+++ b/src/components/common/Like.tsx
@@ -50,6 +50,7 @@ const StImageContainer = styled.div<{ fromList: boolean }>`
       ? css`
           .like {
             position: absolute;
+            top: 0.2rem;
             right: 0.2rem;
 
             width: 4rem;
@@ -60,6 +61,7 @@ const StImageContainer = styled.div<{ fromList: boolean }>`
       : css`
           .like {
             position: absolute;
+            top: 1.2rem;
             right: 1.2rem;
 
             width: 5rem;

--- a/src/components/common/NewsList.tsx
+++ b/src/components/common/NewsList.tsx
@@ -20,7 +20,7 @@ function NewsList(props: NewsListProps) {
         <StNewsWrapper key={id} onClick={() => router.push(`/learn/${id}`)}>
           <StThumbnail>
             <ImageDiv className="thumbnail" src={thumbnail} layout="fill" alt="" />
-            <Like fromList={true} />
+            <Like isFromList={true} />
           </StThumbnail>
           <StTitle>{title}</StTitle>
           <StInfo>

--- a/src/components/common/NewsList.tsx
+++ b/src/components/common/NewsList.tsx
@@ -20,7 +20,7 @@ function NewsList(props: NewsListProps) {
         <StNewsWrapper key={id} onClick={() => router.push(`/learn/${id}`)}>
           <StThumbnail>
             <ImageDiv className="thumbnail" src={thumbnail} layout="fill" alt="" />
-            <Like />
+            <Like fromList={true} />
           </StThumbnail>
           <StTitle>{title}</StTitle>
           <StInfo>

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -73,7 +73,7 @@ function LearnDetail({ videoData }: { videoData: VideoData }) {
               </StTagContainer>
             </StVideoDetail>
             <StVideoWrapper>
-              <Like fromList={false} />
+              <Like isFromList={false} />
               <YouTube
                 videoId={link}
                 opts={{

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import ImageDiv from '../../components/common/ImageDiv';
 import GuideModal from '@src/components/learnDetail/GuideModal';
 import HighlightModal from '@src/components/learnDetail/HighlightModal';
-import { icXButton, icGuide, icMemo, icAnnounce, icHighlighter, icSpacing, icLikeDefault } from 'public/assets/icons';
+import { icXButton, icGuide, icMemo, icAnnounce, icHighlighter, icSpacing } from 'public/assets/icons';
 import { COLOR } from '@src/styles/color';
 import { FONT_STYLES } from '@src/styles/fontStyle';
 import { GetServerSidePropsContext } from 'next';
@@ -12,6 +12,7 @@ import { api } from '@src/services/api';
 import { VideoData } from '@src/services/api/types/learn-detail';
 import YouTube from 'react-youtube';
 import SEO from '@src/components/common/SEO';
+import Like from '@src/components/common/Like';
 
 function LearnDetail({ videoData }: { videoData: VideoData }) {
   const router = useRouter();
@@ -72,7 +73,7 @@ function LearnDetail({ videoData }: { videoData: VideoData }) {
               </StTagContainer>
             </StVideoDetail>
             <StVideoWrapper>
-              <ImageDiv src={icLikeDefault} className="like-button" layout="fill" />
+              <Like fromList={false} />
               <YouTube
                 videoId={link}
                 opts={{


### PR DESCRIPTION
## 🚩 관련 이슈
- close #49

## 📋 작업 내용
- [x] 좋아요 스타일링
- [x] Like 컴포넌트에서 props 받기 

## 📌 PR Point
- 뉴스 리스트에서의 좋아요는 기존에 안보이다가 호버시에 나타나는데 학습 상세 페이지의 좋아요는 처음부터 드러나있기 때문에 이를 fromList라는 boolean타입의 props를 이용하여 구분하였습니다.
- 스타일링 코드를 더 깔끔하게 짤 수 있는 방법이 있으면 알려주시면 감사하겠습니다.

## 📸 스크린샷

https://user-images.githubusercontent.com/63948884/179482522-f9b7b507-75ed-45a1-bf72-1aa155afe736.mp4

