### PR TITLE
[home] 홈 뷰 추천 영상 조회 실서버 API 붙이기 

### DIFF
--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -37,7 +37,7 @@ export default Home;
 
 export async function getServerSideProps() {
   const response = await api.homeService.getVideoData();
-  return { props: { videoData: response.videoListData } };
+  return { props: { videoData: response.videoList } };
 }
 
 const StHome = styled.div`

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -37,7 +37,7 @@ export default Home;
 
 export async function getServerSideProps() {
   const response = await api.homeService.getVideoData();
-  return { props: { videoData: response.videoList } };
+  return { props: { videoData: response.videoListData } };
 }
 
 const StHome = styled.div`

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -37,7 +37,7 @@ export default Home;
 
 export async function getServerSideProps() {
   const response = await api.homeService.getVideoData();
-  return { props: { videoData: response } };
+  return { props: { videoData: response.videoList } };
 }
 
 const StHome = styled.div`

--- a/src/services/api/home.ts
+++ b/src/services/api/home.ts
@@ -1,5 +1,5 @@
-import { getRecommendVideoResponse } from './types/home';
+import { VideoListData } from './types/home';
 
 export interface HomeService {
-  getVideoData(): Promise<getRecommendVideoResponse>;
+  getVideoData(): Promise<VideoListData>;
 }

--- a/src/services/api/home.ts
+++ b/src/services/api/home.ts
@@ -1,5 +1,5 @@
-import { VideoData } from './types/home';
+import { getRecommendVideoResponse } from './types/home';
 
 export interface HomeService {
-  getVideoData(): Promise<VideoData[]>;
+  getVideoData(): Promise<getRecommendVideoResponse>;
 }

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -1,5 +1,5 @@
 import { HomeService } from './home';
-import { homeDataMock } from '../mock/home';
+import { homeDataRemote } from '../remote/home';
 import { LearnService } from './learn';
 import { learnDataRemote } from '../remote/learn';
 import { LearnDetailService } from './learn-detail';
@@ -12,7 +12,7 @@ function getAPIMethod(): APIService {
 }
 
 function provideMockAPIService(): APIService {
-  const homeService = homeDataMock();
+  const homeService = homeDataRemote();
   const learnService = learnDataRemote();
   const learnDetailService = learnDetailDataRemote();
   return { homeService, learnService, learnDetailService };

--- a/src/services/api/types/home.ts
+++ b/src/services/api/types/home.ts
@@ -6,3 +6,7 @@ export type VideoData = {
   thumbnail: string;
   reportDate: string;
 };
+
+export type getRecommendVideoResponse = {
+  videoList: VideoData[];
+};

--- a/src/services/api/types/home.ts
+++ b/src/services/api/types/home.ts
@@ -7,6 +7,6 @@ export type VideoData = {
   reportDate: string;
 };
 
-export type getRecommendVideoResponse = {
-  videoListData: VideoData[];
+export type VideoListData = {
+  videoList: VideoData[];
 };

--- a/src/services/api/types/home.ts
+++ b/src/services/api/types/home.ts
@@ -8,5 +8,5 @@ export type VideoData = {
 };
 
 export type getRecommendVideoResponse = {
-  videoList: VideoData[];
+  videoListData: VideoData[];
 };

--- a/src/services/mock/home.data.ts
+++ b/src/services/mock/home.data.ts
@@ -1,5 +1,5 @@
 export const HOME_DATA = {
-  videoList: [
+  videoListData: [
     {
       id: 12,
       title: '손님들이 건넨 술 마시고 사망…함께 있던 남성은 사고사',

--- a/src/services/mock/home.data.ts
+++ b/src/services/mock/home.data.ts
@@ -1,5 +1,5 @@
 export const HOME_DATA = {
-  videoListData: [
+  videoList: [
     {
       id: 12,
       title: '손님들이 건넨 술 마시고 사망…함께 있던 남성은 사고사',

--- a/src/services/mock/home.data.ts
+++ b/src/services/mock/home.data.ts
@@ -1,5 +1,5 @@
 export const HOME_DATA = {
-  VIDEO_DATA: [
+  videoList: [
     {
       id: 12,
       title: '손님들이 건넨 술 마시고 사망…함께 있던 남성은 사고사',

--- a/src/services/mock/home.ts
+++ b/src/services/mock/home.ts
@@ -4,7 +4,7 @@ import { HOME_DATA } from './home.data';
 export function homeDataMock(): HomeService {
   const getVideoData = async () => {
     await wait(500);
-    return HOME_DATA.VIDEO_DATA;
+    return HOME_DATA;
   };
 
   return { getVideoData };

--- a/src/services/remote/home.ts
+++ b/src/services/remote/home.ts
@@ -5,18 +5,20 @@ import { publicAPI } from './base';
 export function homeDataRemote(): HomeService {
   const getVideoData = async () => {
     const response = await publicAPI.get({ url: `/news/recommend` });
-    return {
-      videoList: response.data
-        ? response.data.map((video: VideoData) => ({
-            id: video.id,
-            title: video.title,
-            category: video.category,
-            channel: video.channel,
-            thumbnail: video.thumbnail,
-            reportDate: video.reportDate,
-          }))
-        : [],
-    };
+    if (response.status === 200) {
+      return {
+        videoList: response.data
+          ? response.data.map((video: VideoData) => ({
+              id: video.id,
+              title: video.title,
+              category: video.category,
+              channel: video.channel,
+              thumbnail: video.thumbnail,
+              reportDate: video.reportDate,
+            }))
+          : [],
+      };
+    } else throw '서버 통신 실패';
   };
 
   return { getVideoData };

--- a/src/services/remote/home.ts
+++ b/src/services/remote/home.ts
@@ -1,0 +1,23 @@
+import { VideoData } from '../api/types/home';
+import { HomeService } from './../api/home';
+import { publicAPI } from './base';
+
+export function homeDataRemote(): HomeService {
+  const getVideoData = async () => {
+    const response = await publicAPI.get({ url: `/news/recommend` });
+    return {
+      videoList: response.data
+        ? response.data.map((video: VideoData) => ({
+            id: video.id,
+            title: video.title,
+            category: video.category,
+            channel: video.channel,
+            thumbnail: video.thumbnail,
+            reportDate: video.reportDate,
+          }))
+        : [],
+    };
+  };
+
+  return { getVideoData };
+}

--- a/src/services/remote/home.ts
+++ b/src/services/remote/home.ts
@@ -7,7 +7,7 @@ export function homeDataRemote(): HomeService {
     const response = await publicAPI.get({ url: `/news/recommend` });
     if (response.status === 200) {
       return {
-        videoList: response.data
+        videoListData: response.data
           ? response.data.map((video: VideoData) => ({
               id: video.id,
               title: video.title,

--- a/src/services/remote/home.ts
+++ b/src/services/remote/home.ts
@@ -7,7 +7,7 @@ export function homeDataRemote(): HomeService {
     const response = await publicAPI.get({ url: `/news/recommend` });
     if (response.status === 200) {
       return {
-        videoListData: response.data
+        videoList: response.data
           ? response.data.map((video: VideoData) => ({
               id: video.id,
               title: video.title,


### PR DESCRIPTION
## 🚩 관련 이슈
- close #56

## 📋 작업 내용
- [x] 홈 뷰 추천 영상 조회 실서버 API 붙이기

## 📌 PR Point
- 기존에는 api/types/home.ts에 VideoData 타입만 있었고 getVideoData함수의 타입이 Promise<VideoData[]>였는데 remote/home.ts에서 반환을 해줄 때 어떻게 해줘야 하는지 감이 안와서 지연이의 코드를 참고해 api/types/home.ts에 

```
export type getRecommendVideoResponse = {
  videoList: VideoData[];
};
```
위와 같은 타입을 만들어주고 remote/home.ts에서 반환을 할 때 아래와 같이 해주었습니다. 

```
return {
      videoList: response.data
        ? response.data.map((video: VideoData) => ({
            id: video.id,
            title: video.title,
            category: video.category,
            channel: video.channel,
            thumbnail: video.thumbnail,
            reportDate: video.reportDate,
          }))
        : [],
    };
```
그리고 getVideoData 함수의 타입을 아래와 같이 Promise<getRecommendVideoResponse>로 바꾸어 주었습니다.
```
export interface HomeService {
  getVideoData(): Promise<getRecommendVideoResponse>;
}
```
getRecommendVideoResponse 타입을 만들지 않고 반환하는 방법이 있을까요?


## 📸 스크린샷

![image](https://user-images.githubusercontent.com/63948884/179560506-ecfbd17e-e313-47f0-8ef3-4cef659c7bb0.png)
