### PR TITLE
[home] 추천 뉴스 스켈레톤 UI 적용

### DIFF
--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -7,8 +7,22 @@ import { api } from '@src/services/api';
 import { VideoData } from '@src/services/api/types/home';
 import Footer from '@src/components/common/Footer';
 import SEO from '@src/components/common/SEO';
+import { useEffect, useState } from 'react';
+import VideoListSkeleton from '@src/components/common/VideoListSkeleton';
 
-function Home({ videoData }: { videoData: VideoData[] }) {
+function Home() {
+  const [newsList, setNewsList] = useState<VideoData[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      setIsLoading(true);
+      const { videoList } = await api.homeService.getVideoData();
+      setNewsList(videoList);
+      setIsLoading(false);
+    })();
+  }, []);
+
   return (
     <>
       <SEO title="Deliverble" />
@@ -24,9 +38,7 @@ function Home({ videoData }: { videoData: VideoData[] }) {
       </StHome>
       <StNews>
         <h3>딜리버블의 추천 뉴스를 만나보세요.</h3>
-        <div>
-          <NewsList newsList={videoData} />
-        </div>
+        <div>{isLoading ? <VideoListSkeleton itemNumber={8} /> : <NewsList newsList={newsList} />}</div>
       </StNews>
       <Footer />
     </>
@@ -35,10 +47,10 @@ function Home({ videoData }: { videoData: VideoData[] }) {
 
 export default Home;
 
-export async function getServerSideProps() {
-  const response = await api.homeService.getVideoData();
-  return { props: { videoData: response.videoList } };
-}
+// export async function getServerSideProps() {
+//   const response = await api.homeService.getVideoData();
+//   return { props: { videoData: response.videoList } };
+// }
 
 const StHome = styled.div`
   display: flex;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #52 

## 📋 작업 내용
- [x] home에서 props로 8넘기기 (동영상 개수 8개)
- [x] api 호출 코드 변경 

## 📌 PR Point
- Network Presets를 Fast 3G로 하고 홈 화면을 새로 고침하면 흰 화면이 굉장히 오랫동안 보이는데 이게 맞나요..? 제가 알기로 자바스크립트가 로드가 되기 전에 흰 화면이 나오는 건 CSR의 특징이라고 알고 있었는데 왜 넥스트에서도 이러는 건지 궁금합니다.. 로드 중에 소스코드를 보면 HTML 코드가 잘 보이긴 하는데 화면에 나타나는 건 없네요? 제가 놓치고 있는 개념이 있다면 알려주시면 감사하겠습니다. 
- 큰 작업이 아니라서 메모 추가 작업을 하면서 같이 할까 했는데 아무래도 이슈를 분리하는 게 더 나은 것 같아서 분리하고 PR 올립니다. 

## 📸 스크린샷

https://user-images.githubusercontent.com/63948884/179717840-0c9e2fe2-dc5f-4a24-bea4-f530fbec5798.mp4


