### PR TITLE
[learn_detail] 하이라이트 우클릭 컨텍스트 메뉴

### DIFF
--- a/src/components/learnDetail/ContextMenu.tsx
+++ b/src/components/learnDetail/ContextMenu.tsx
@@ -53,11 +53,14 @@ const StContextMenu = styled.div<{ top: number; left: number }>`
     height: 3.2rem;
     padding: 0.5rem 1.6rem;
 
+    border-radius: 0.8rem;
     ${FONT_STYLES.SB_16_CAPTION}
     color: ${COLOR.BLACK};
   }
 
   & > ul > li:hover {
     cursor: pointer;
+    transition: background-color 0.3s ease-in-out;
+    background-color: ${COLOR.GRAY_5};
   }
 `;

--- a/src/components/learnDetail/ContextMenu.tsx
+++ b/src/components/learnDetail/ContextMenu.tsx
@@ -1,0 +1,63 @@
+import { COLOR } from '@src/styles/color';
+import { FONT_STYLES } from '@src/styles/fontStyle';
+import styled, { css } from 'styled-components';
+
+interface ContextMenuProps {
+  points: {
+    x: number;
+    y: number;
+  };
+}
+
+function ContextMenu(props: ContextMenuProps) {
+  const { x, y } = props.points;
+
+  return (
+    <StContextMenu top={y} left={x} className="test">
+      <ul>
+        <li>메모 추가</li>
+        <li>하이라이트 삭제</li>
+      </ul>
+    </StContextMenu>
+  );
+}
+
+export default ContextMenu;
+
+const StContextMenu = styled.div<{ top: number; left: number }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  position: absolute;
+  width: 14.4rem;
+  height: 8rem;
+  z-index: 1;
+
+  border-radius: 1.2rem;
+  border: 1px solid ${COLOR.GRAY_10};
+  background-color: ${COLOR.WHITE};
+  box-shadow: 0.4rem 0.4rem 2rem rgba(22, 15, 53, 0.15);
+
+  ${({ top, left }) => css`
+    top: ${top}rem;
+    left: ${left}rem;
+  `}
+
+  & > ul > li {
+    display: flex;
+    justify-content: center;
+
+    width: 13.2rem;
+    height: 3.2rem;
+    padding: 0.5rem 1.6rem;
+
+    ${FONT_STYLES.SB_16_CAPTION}
+    color: ${COLOR.BLACK};
+  }
+
+  & > ul > li:hover {
+    cursor: pointer;
+  }
+`;

--- a/src/components/learnDetail/ScriptEdit.tsx
+++ b/src/components/learnDetail/ScriptEdit.tsx
@@ -1,6 +1,5 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { COLOR } from '@src/styles/color';
-import { useEffect, useRef, useState } from 'react';
 
 interface ScriptType {
   id: number;
@@ -70,91 +69,10 @@ function ScriptEdit(props: ScriptEditProps) {
     }
   };
 
-  // const testRef = useRef<any>();
-
-  // let x: any;
-  // let y: any;
-  // document.addEventListener('contextmenu', function (e) {
-  //   e.preventDefault(); // 원래 있던 오른쪽 마우스 이벤트를 무효화한다.
-  //   x = e.pageX + 'px'; // 현재 마우스의 X좌표
-  //   y = e.pageY + 'px'; // 현재 마우스의 Y좌표
-  //   // console.log('x', x);
-  // });
-
-  // function handleCreateContextMenu(event: any) {
-  //   event.preventDefault();
-
-  //   // console.log('event', event.target);
-  //   console.log('pageX', event.pageX);
-  //   console.log('pageY', event.pageY);
-  //   // console.log('X', event.pageX - 578);
-  //   // console.log('Y', event.pageY - 301);
-
-  //   // console.log('getBoundingClientRect', event.target.getBoundingClientRect());
-
-  //   console.log('getBoundingClientRect x', event.target.getBoundingClientRect().x);
-  //   console.log('getBoundingClientRect y', event.target.getBoundingClientRect().y);
-  //   // console.log('getBoundingClientRect width', event.target.getBoundingClientRect().width);
-  //   // console.log('getBoundingClientRect height', event.target.getBoundingClientRect().height);
-
-  //   if (event.target.outerHTML.slice(0, 6) === '<mark>') {
-  //     testRef.current.style.position = 'absolute';
-  //     // testRef.current.style.left = event.pageX - event.target.getBoundingClientRect().x + 'px';
-  //     // testRef.current.style.top = event.pageY - event.target.getBoundingClientRect().y + 'px';
-  //     testRef.current.style.left = event.pageX - event.target.getBoundingClientRect().x + 'px';
-  //     testRef.current.style.top = event.pageY - event.target.getBoundingClientRect().y + 'px';
-  //     // testRef.current.style.left = '30px';
-  //     // testRef.current.style.top = '30px';
-  //     testRef.current.style.display = 'block';
-  //     testRef.current.style.backgroundColor = 'red';
-  //   }
-  // }
-
-  // const testRef = useRef();
-
-  //   const popMenu = document.getElementById('popMenu'); // 팝업창을 담아옴
-  //   // const popMenu = testRef.current();
-  //   console.log('test');
-  //   console.log(popMenu);
-
-  //   // popMenu.style.position = 'relative';
-  //   // popMenu.style.left = x;
-  //   // popMenu.style.top = y;
-  //   // popMenu.style.display = 'block';
-  // });
-
-  //클릭시 메뉴 숨기기
-  // document.addEventListener('click', function (e) {
-  //   // 노출 초기화
-  //   popMenu.style.display = 'none';
-  //   popMenu.style.top = null;
-  //   popMenu.style.left = null;
-  // });
-
-  const [show, setShow] = useState(false);
-  const [points, setPoints] = useState({ x: 0, y: 0 });
-
-  useEffect(() => {
-    const handleClick = () => setShow(false);
-    window.addEventListener('click', handleClick);
-    return () => window.removeEventListener('click', handleClick);
-  }, []);
-
   return (
     <StWrapper
       contentEditable="true"
       onClick={handleClick}
-      onContextMenu={(e) => {
-        e.preventDefault();
-        setShow(true);
-        console.log(e.target);
-        console.log('offsetX', e.nativeEvent.offsetX);
-        console.log('offsetY', e.nativeEvent.offsetY);
-        setPoints({
-          x: e.nativeEvent.offsetX / 10 + (e.nativeEvent.offsetX / 10) * 0.5,
-          y: e.nativeEvent.offsetY / 10 + (e.nativeEvent.offsetY / 10) * 2,
-        });
-      }}
       suppressContentEditableWarning={true}
       spellCheck="false"
       onCut={(e) => e.preventDefault()}
@@ -162,17 +80,7 @@ function ScriptEdit(props: ScriptEditProps) {
       onPaste={(e) => e.preventDefault()}
       onKeyDown={(e) => e.preventDefault()}>
       {scripts.map(({ id, text }) => (
-        <StScriptText key={id}>
-          {text}
-          {show && (
-            <StContextMenu top={points.y} left={points.x}>
-              <ul>
-                <li>Delete</li>
-                <li>Edit</li>
-              </ul>
-            </StContextMenu>
-          )}
-        </StScriptText>
+        <StScriptText key={id}>{text}</StScriptText>
       ))}
     </StWrapper>
   );
@@ -230,37 +138,5 @@ const StScriptText = styled.div`
     & > .right {
       margin-left: 0.4rem;
     }
-  }
-`;
-
-type ContextMenuProps = {
-  top: number;
-  left: number;
-};
-
-const StContextMenu = styled.div<ContextMenuProps>`
-  border-radius: 4px;
-  box-sizing: border-box;
-  position: absolute;
-  width: 100px;
-  background-color: white;
-  box-shadow: 0px 1px 8px 0px rgba(0, 0, 0, 0.1);
-  ${({ top, left }) => css`
-    top: ${top}rem;
-    left: ${left}rem;
-  `}
-  ul {
-    list-style-type: none;
-    box-sizing: border-box;
-    margin: 0;
-    padding: 10px;
-  }
-  ul li {
-    /* padding: 8px 2px;
-    border-radius: 4px; */
-  }
-
-  ul li:hover {
-    cursor: pointer;
   }
 `;

--- a/src/components/learnDetail/memo/MemoPopup.tsx
+++ b/src/components/learnDetail/memo/MemoPopup.tsx
@@ -12,8 +12,10 @@ function MemoPopup(props: MemoPopupProps) {
   return (
     <>
       <StMemoPopup>
-        <StMemoEdit onClick={memoEdit}>메모 수정</StMemoEdit>
-        <StMemoDelete>메모 삭제</StMemoDelete>
+        <button type="button" onClick={memoEdit}>
+          메모 수정
+        </button>
+        <button type="button">메모 삭제</button>
       </StMemoPopup>
     </>
   );
@@ -38,25 +40,19 @@ const StMemoPopup = styled.div`
   border: 1px solid ${COLOR.GRAY_10};
   border-radius: 1.2rem;
   background-color: ${COLOR.WHITE};
+  box-shadow: 0.4rem 0.4rem 2rem rgba(22, 15, 53, 0.15);
+
+  & > button {
+    width: 9.1rem;
+    height: 3.2rem;
+
+    border-radius: 0.8rem;
+    color: ${COLOR.BLACK};
+    ${FONT_STYLES.SB_16_CAPTION};
+  }
 
   & > button:hover {
     transition: background-color 0.3s ease-in-out;
     background-color: ${COLOR.GRAY_5};
   }
-`;
-
-const StMemoEdit = styled.button`
-  width: 9.1rem;
-  height: 3.2rem;
-
-  color: ${COLOR.BLACK};
-  ${FONT_STYLES.SB_16_CAPTION};
-`;
-
-const StMemoDelete = styled.button`
-  width: 9.1rem;
-  height: 3.2rem;
-
-  color: ${COLOR.BLACK};
-  ${FONT_STYLES.SB_16_CAPTION};
 `;

--- a/src/components/learnDetail/memo/MemoPopup.tsx
+++ b/src/components/learnDetail/memo/MemoPopup.tsx
@@ -38,6 +38,11 @@ const StMemoPopup = styled.div`
   border: 1px solid ${COLOR.GRAY_10};
   border-radius: 1.2rem;
   background-color: ${COLOR.WHITE};
+
+  & > button:hover {
+    transition: background-color 0.3s ease-in-out;
+    background-color: ${COLOR.GRAY_5};
+  }
 `;
 
 const StMemoEdit = styled.button`

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -47,11 +47,6 @@ function Home() {
 
 export default Home;
 
-// export async function getServerSideProps() {
-//   const response = await api.homeService.getVideoData();
-//   return { props: { videoData: response.videoList } };
-// }
-
 const StHome = styled.div`
   display: flex;
   align-items: center;

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -75,6 +75,16 @@ function LearnDetail({ videoData, memoData }: { videoData: VideoData; memoData: 
   const [clickedScriptId, setClickedScriptId] = useState<number>();
   const [points, setPoints] = useState({ x: 0, y: 0 });
 
+  const controlPointX = (e: any) => {
+    const x = e.offsetX / 10;
+    const y = e.offsetY / 10;
+
+    if (x > 40) {
+      return { x: x + x * 0.2, y: y + y * 0.5 };
+    }
+    return { x: x + x * 0.5, y: y + y * 0.5 };
+  };
+
   return (
     <>
       <SEO title="학습하기 | Deliverble" />
@@ -134,10 +144,7 @@ function LearnDetail({ videoData, memoData }: { videoData: VideoData; memoData: 
                       onContextMenu={(e) => {
                         e.preventDefault();
                         setClickedScriptId(id);
-                        setPoints({
-                          x: e.nativeEvent.offsetX / 10 + (e.nativeEvent.offsetX / 10) * 0.5,
-                          y: e.nativeEvent.offsetY / 10 + (e.nativeEvent.offsetY / 10) * 0.5,
-                        });
+                        setPoints(controlPointX(e.nativeEvent));
                       }}
                       key={id}
                       onClick={() => player?.seekTo(startTime, true)}

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect, BaseSyntheticEvent } from 'react';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import ImageDiv from '../../components/common/ImageDiv';
@@ -75,9 +75,9 @@ function LearnDetail({ videoData, memoData }: { videoData: VideoData; memoData: 
   const [clickedScriptId, setClickedScriptId] = useState<number>();
   const [points, setPoints] = useState({ x: 0, y: 0 });
 
-  const controlPointX = (e: any) => {
-    const x = e.offsetX / 10;
-    const y = e.offsetY / 10;
+  const controlPointX = (e: React.MouseEvent) => {
+    const x = e.nativeEvent.offsetX / 10;
+    const y = e.nativeEvent.offsetY / 10;
 
     if (x > 40) {
       return { x: x + x * 0.2, y: y + y * 0.5 };
@@ -144,7 +144,7 @@ function LearnDetail({ videoData, memoData }: { videoData: VideoData; memoData: 
                       onContextMenu={(e) => {
                         e.preventDefault();
                         setClickedScriptId(id);
-                        setPoints(controlPointX(e.nativeEvent));
+                        setPoints(controlPointX(e));
                       }}
                       key={id}
                       onClick={() => player?.seekTo(startTime, true)}

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import ImageDiv from '../../components/common/ImageDiv';
 import GuideModal from '@src/components/learnDetail/GuideModal';
 import HighlightModal from '@src/components/learnDetail/HighlightModal';
@@ -28,6 +28,7 @@ import EmptyMemo from '@src/components/learnDetail/memo/EmptyMemo';
 import SEO from '@src/components/common/SEO';
 import MemoList from '@src/components/learnDetail/memo/MemoList';
 import Like from '@src/components/common/Like';
+import ContextMenu from '@src/components/learnDetail/ContextMenu';
 
 function LearnDetail({ videoData, memoData }: { videoData: VideoData; memoData: MemoData[] }) {
   const router = useRouter();
@@ -71,13 +72,8 @@ function LearnDetail({ videoData, memoData }: { videoData: VideoData; memoData: 
   const [isHighlight, setIsHighlight] = useState(false);
   const [isSpacing, setIsSpacing] = useState(false);
 
-  const [clickedId, setClickedId] = useState<number>();
+  const [clickedScriptId, setClickedScriptId] = useState<number>();
   const [points, setPoints] = useState({ x: 0, y: 0 });
-
-  // const setShowId = (id: number) => {
-  //   window.addEventListener('click', () => setClickedId(id));
-  //   return () => window.removeEventListener('click', () => setClickedId(id));
-  // };
 
   return (
     <>
@@ -137,10 +133,7 @@ function LearnDetail({ videoData, memoData }: { videoData: VideoData; memoData: 
                     <StScriptText
                       onContextMenu={(e) => {
                         e.preventDefault();
-                        setClickedId(id); // 우클릭한 하이라이트가 속한 문장의 아이디
-                        // setShowId(id);
-                        console.log('offsetX', e.nativeEvent.offsetX);
-                        console.log('offsetY', e.nativeEvent.offsetY);
+                        setClickedScriptId(id);
                         setPoints({
                           x: e.nativeEvent.offsetX / 10 + (e.nativeEvent.offsetX / 10) * 0.5,
                           y: e.nativeEvent.offsetY / 10 + (e.nativeEvent.offsetY / 10) * 0.5,
@@ -150,14 +143,7 @@ function LearnDetail({ videoData, memoData }: { videoData: VideoData; memoData: 
                       onClick={() => player?.seekTo(startTime, true)}
                       isActive={startTime <= currentTime && currentTime <= endTime ? true : false}>
                       {text}
-                      {clickedId == id && (
-                        <StContextMenu top={points.y} left={points.x} className="test">
-                          <ul>
-                            <li>메모 추가</li>
-                            <li>하이라이트 삭제</li>
-                          </ul>
-                        </StContextMenu>
-                      )}
+                      {clickedScriptId == id && <ContextMenu points={points} />}
                     </StScriptText>
                   ))}
                 {(isHighlight || isSpacing) && (
@@ -339,7 +325,7 @@ const StScriptText = styled.p<{ isActive: boolean }>`
   color: ${({ isActive }) => (isActive ? COLOR.MAIN_BLUE : COLOR.BLACK)};
   cursor: pointer;
 
-  &:not(& div):hover {
+  &:hover {
     color: ${COLOR.MAIN_BLUE};
     font-weight: 600;
   }
@@ -452,47 +438,4 @@ const StMemoTitle = styled.div`
 const StMemoWrapper = styled.div`
   display: flex;
   justify-content: center;
-`;
-
-type ContextMenuProps = {
-  top: number;
-  left: number;
-};
-
-const StContextMenu = styled.div<ContextMenuProps>`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-
-  position: absolute;
-  width: 14.4rem;
-  height: 8rem;
-  z-index: 1;
-
-  border-radius: 1.2rem;
-  border: 1px solid ${COLOR.GRAY_10};
-  background-color: ${COLOR.WHITE};
-  box-shadow: 0.4rem 0.4rem 2rem rgba(22, 15, 53, 0.15);
-
-  ${({ top, left }) => css`
-    top: ${top}rem;
-    left: ${left}rem;
-  `}
-
-  & > ul > li {
-    display: flex;
-    justify-content: center;
-
-    width: 13.2rem;
-    height: 3.2rem;
-    padding: 0.5rem 1.6rem;
-
-    ${FONT_STYLES.SB_16_CAPTION}
-    color: ${COLOR.BLACK};
-  }
-
-  & > ul > li:hover {
-    cursor: pointer;
-  }
 `;

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, BaseSyntheticEvent } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import ImageDiv from '../../components/common/ImageDiv';

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import ImageDiv from '../../components/common/ImageDiv';
 import GuideModal from '@src/components/learnDetail/GuideModal';
 import HighlightModal from '@src/components/learnDetail/HighlightModal';
@@ -71,6 +71,14 @@ function LearnDetail({ videoData, memoData }: { videoData: VideoData; memoData: 
   const [isHighlight, setIsHighlight] = useState(false);
   const [isSpacing, setIsSpacing] = useState(false);
 
+  const [clickedId, setClickedId] = useState<number>();
+  const [points, setPoints] = useState({ x: 0, y: 0 });
+
+  // const setShowId = (id: number) => {
+  //   window.addEventListener('click', () => setClickedId(id));
+  //   return () => window.removeEventListener('click', () => setClickedId(id));
+  // };
+
   return (
     <>
       <SEO title="학습하기 | Deliverble" />
@@ -127,10 +135,29 @@ function LearnDetail({ videoData, memoData }: { videoData: VideoData; memoData: 
                   !isSpacing &&
                   scripts.map(({ id, text, startTime, endTime }) => (
                     <StScriptText
+                      onContextMenu={(e) => {
+                        e.preventDefault();
+                        setClickedId(id); // 우클릭한 하이라이트가 속한 문장의 아이디
+                        // setShowId(id);
+                        console.log('offsetX', e.nativeEvent.offsetX);
+                        console.log('offsetY', e.nativeEvent.offsetY);
+                        setPoints({
+                          x: e.nativeEvent.offsetX / 10 + (e.nativeEvent.offsetX / 10) * 0.5,
+                          y: e.nativeEvent.offsetY / 10 + (e.nativeEvent.offsetY / 10) * 0.5,
+                        });
+                      }}
                       key={id}
                       onClick={() => player?.seekTo(startTime, true)}
                       isActive={startTime <= currentTime && currentTime <= endTime ? true : false}>
                       {text}
+                      {clickedId == id && (
+                        <StContextMenu top={points.y} left={points.x} className="test">
+                          <ul>
+                            <li>메모 추가</li>
+                            <li>하이라이트 삭제</li>
+                          </ul>
+                        </StContextMenu>
+                      )}
                     </StScriptText>
                   ))}
                 {(isHighlight || isSpacing) && (
@@ -305,15 +332,22 @@ const StLearnSection = styled.section`
 `;
 
 const StScriptText = styled.p<{ isActive: boolean }>`
+  position: relative;
+
   font-size: 2.6rem;
   font-weight: ${({ isActive }) => (isActive ? 600 : 400)};
   color: ${({ isActive }) => (isActive ? COLOR.MAIN_BLUE : COLOR.BLACK)};
   cursor: pointer;
 
-  &:hover {
+  &:not(& div):hover {
     color: ${COLOR.MAIN_BLUE};
     font-weight: 600;
   }
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 `;
 
 const StButtonContainer = styled.div`
@@ -418,4 +452,47 @@ const StMemoTitle = styled.div`
 const StMemoWrapper = styled.div`
   display: flex;
   justify-content: center;
+`;
+
+type ContextMenuProps = {
+  top: number;
+  left: number;
+};
+
+const StContextMenu = styled.div<ContextMenuProps>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  position: absolute;
+  width: 14.4rem;
+  height: 8rem;
+  z-index: 1;
+
+  border-radius: 1.2rem;
+  border: 1px solid ${COLOR.GRAY_10};
+  background-color: ${COLOR.WHITE};
+  box-shadow: 0.4rem 0.4rem 2rem rgba(22, 15, 53, 0.15);
+
+  ${({ top, left }) => css`
+    top: ${top}rem;
+    left: ${left}rem;
+  `}
+
+  & > ul > li {
+    display: flex;
+    justify-content: center;
+
+    width: 13.2rem;
+    height: 3.2rem;
+    padding: 0.5rem 1.6rem;
+
+    ${FONT_STYLES.SB_16_CAPTION}
+    color: ${COLOR.BLACK};
+  }
+
+  & > ul > li:hover {
+    cursor: pointer;
+  }
 `;

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -329,11 +329,6 @@ const StScriptText = styled.p<{ isActive: boolean }>`
     color: ${COLOR.MAIN_BLUE};
     font-weight: 600;
   }
-
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
 `;
 
 const StButtonContainer = styled.div`


### PR DESCRIPTION
## 🚩 관련 이슈
- close #59 

## 📋 작업 내용
- [x] 하이라이트 우클릭하면 컨텍스트 메뉴 띄우기

## 📌 PR Point
- 마우스를 클릭한 자리에 컨텍스트 메뉴가 나타납니다. 
- 마우스의 오른쪽에 나타나게 했는데 줄의 오른쪽 끝 부분에서 클릭할 경우 창의 기존 범위를 넘어가게 되어 그 부분에서는 마우스 왼쪽으로 컨텍스트 메뉴가 나타나게 했습니다.

- 스크립트가 길어서 스크립트에 스크롤이 있는 경우 마지막 줄에서 컨텍스트 메뉴를 띄우면 아래쪽 그림자가 살짝 잘리는데 해결 방법을 아시고 계시면 알려주세요. 
- 스크립트가 div안에 있어서 offset을 이용하여 좌표를 구하고자 했는데 컨텍스트 메뉴가 좌표대로 잘 나타나지 않았습니다. 분명 console에 찍히는 좌표와 컨텍스트 메뉴의 left 값이 동일한데 컨텍스트 메뉴가 좌표보다 더 왼쪽에 있어서 일단 임의대로 계산을 해서 기존의 x 좌표에 x * 0.5 만큼의 길이를 더하여서 마우스 오른쪽에 나타나게 하였습니다. (y도 마찬가지) 도저히 컨텍스트 메뉴가 왜 좌표대로 나타나지 않는지 모르겠는데 아시는 분이 있다면 알려주시면 감사하겠습니다. 


## 📸 스크린샷

https://user-images.githubusercontent.com/63948884/179997358-7fdea287-df43-4cb5-8472-98ed5a844baf.mp4
