### PR TITLE
[common] 프로필 모달 디자인 수정

### DIFF
--- a/src/components/common/ProfileModal.tsx
+++ b/src/components/common/ProfileModal.tsx
@@ -46,7 +46,6 @@ const StProfileModal = styled.div`
   top: 7.6rem;
   right: 4rem;
   width: 38rem;
-  height: 28.5rem;
   background-color: ${COLOR.WHITE};
   box-shadow: 4px 4px 20px 0px #160f3526;
   border-radius: 1.034rem;
@@ -55,8 +54,7 @@ const StProfileModal = styled.div`
 
   .profile-image {
     position: relative;
-    margin: 0 auto;
-    margin-bottom: 2rem;
+    margin: 4rem auto 2rem auto;
     width: 5.6rem;
     height: 5.6rem;
   }
@@ -71,14 +69,13 @@ const StProfileModal = styled.div`
 
 const StProfileInfo = styled.div`
   text-align: center;
-  padding-top: 4rem;
-  height: 21.4rem;
 
   & > p {
     ${FONT_STYLES.SB_20_BODY};
   }
 
   & > div {
+    height: 2.6rem;
     ${FONT_STYLES.R_17_CAPTION};
     color: ${COLOR.GRAY_45};
     margin: 0.4rem 0 4rem 0;
@@ -91,6 +88,7 @@ const StLogoutButton = styled.button`
   align-items: center;
   width: 100%;
   height: 7.1rem;
+  margin-top: 4rem;
   ${FONT_STYLES.R_18_CAPTION};
   color: ${COLOR.GRAY_45};
   border-top: 0.1rem ${COLOR.GRAY_10} solid;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #78

## 📋 작업 내용
- [x] 프로필 모달 디자인 수정

## 📌 PR Point
- 사용자가 이메일 제공 동의를 하지 않았을 경우에 프로필 모달의 높이가 이메일이 차지하던 공간만큼 줄어듭니다.

## 📸 스크린샷
<img width="284" alt="스크린샷 2022-07-23 오전 3 20 09" src="https://user-images.githubusercontent.com/99077953/180500264-d68febd0-35cd-4a72-8505-90c967cdef84.png">
<img width="283" alt="스크린샷 2022-07-23 오전 3 20 30" src="https://user-images.githubusercontent.com/99077953/180500320-db59f6e9-c5a8-4158-bc37-0555dd1d7e13.png">

