### PR TITLE
[common] 뉴스 리스트 반응형 구현

### DIFF
--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -71,6 +71,7 @@ const StLogo = styled.div`
   }
 
   & > h4 {
+    min-width: 35.1rem;
     margin-top: 1.6rem;
 
     color: ${COLOR.MAIN_BLUE};
@@ -93,15 +94,18 @@ const StUnderlineText = styled.p`
 `;
 
 const StService = styled.div`
-  padding: 15.1rem 11.7rem 0 0;
+  min-width: 10.8rem;
+  margin: 15.1rem 11.7rem 0 15.1rem;
 `;
 
 const StPeople = styled.div`
-  padding: 15.1rem 10.1em 0 0;
+  min-width: 18.1rem;
+  margin: 15.1rem 10.1em 0 0;
 `;
 
 const StContact = styled.div`
-  padding: 15.1rem 9.4rem 0 0;
+  min-width: 24.7rem;
+  margin: 15.1rem 9.4rem 0 0;
 `;
 
 const StSocial = styled.div`
@@ -109,7 +113,7 @@ const StSocial = styled.div`
   flex-direction: column;
   align-items: center;
 
-  padding: 15.1rem 18rem 0 0;
+  margin: 15.1rem 18rem 0 0;
 
   & > a {
     margin-top: 1.6rem;

--- a/src/components/common/NewsList.tsx
+++ b/src/components/common/NewsList.tsx
@@ -64,6 +64,14 @@ const StNewsList = styled.section`
   grid-template-columns: repeat(4, 1fr);
   grid-row-gap: 11.2rem;
   grid-column-gap: 2rem;
+
+  @media (max-width: 1280px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @media (max-width: 960px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
 `;
 
 const StNewsWrapper = styled.article`

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -153,13 +153,15 @@ const StBannerText = styled.div`
 `;
 
 const StNews = styled.div`
-  padding: 0 16rem 16rem 16rem;
+  padding: 0 0 16rem 16rem;
 
   & > div {
     margin: 0 auto;
+    padding-right: 16rem;
   }
 
   & > h3 {
+    min-width: 4.8rem;
     margin-bottom: 7.2rem;
 
     ${FONT_STYLES.SB_32_HEADLINE}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #121 

## 📋 작업 내용
- [x] 1280px -> 3개 / 960px -> 2개
- [x] 푸터 글씨 고정

## 📌 PR Point
- 창 크기 최대로 줄였을 때 푸터 글씨가 튀어나와서 일단 고정시켜놨는데 나중에 이 부분도 반응형 적용하면 좋을 것 같네요.
 나중에 기획 분들께 의견 여쭤보려고 합니다!

## 📸 스크린샷

https://user-images.githubusercontent.com/63948884/189534109-a3875a74-2f10-4688-8fa9-9dc44c1e9d33.mp4

