### PR TITLE
[learn_detail] QA 반영

### DIFF
--- a/src/components/common/Portal.tsx
+++ b/src/components/common/Portal.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+interface PortalProps {
+  children: ReactNode;
+  selector: string;
+}
+
+function Portal(props: PortalProps) {
+  const { children, selector } = props;
+  const element = typeof window !== 'undefined' && document.querySelector(selector);
+  return element && children ? createPortal(children, element) : null;
+}
+
+export default Portal;

--- a/src/components/learnDetail/GuideModal.tsx
+++ b/src/components/learnDetail/GuideModal.tsx
@@ -101,7 +101,7 @@ const StGuideModalBackground = styled.div`
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.78);
-  z-index: 1;
+  z-index: 2;
 `;
 
 const StGuideModalContent = styled.div`
@@ -113,10 +113,10 @@ const StGuideModalContent = styled.div`
   box-shadow: 0.4rem 0.4rem 2rem rgba(22, 15, 53, 0.15);
 
   position: fixed;
-  top: 42.1rem;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
-  z-index: 2;
+  transform: translate(-50%, -50%);
+  z-index: 3;
 
   & > div {
     & > p {

--- a/src/components/learnDetail/GuideModal.tsx
+++ b/src/components/learnDetail/GuideModal.tsx
@@ -94,7 +94,7 @@ const StGuideModal = styled.div`
 `;
 
 const StGuideModalBackground = styled.div`
-  position: absolute;
+  position: fixed;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);

--- a/src/components/learnDetail/VideoDetail.tsx
+++ b/src/components/learnDetail/VideoDetail.tsx
@@ -10,12 +10,17 @@ interface VideoDetailProps {
   reportDate: string;
   title: string;
   tags: Tag[];
-  setIsModalOpen: (isOpen: boolean) => void;
+  setIsGuideModalOpen: (isOpen: boolean) => void;
 }
 
 function VideoDetail(props: VideoDetailProps) {
-  const { channel, category, reportDate, title, tags, setIsModalOpen } = props;
+  const { channel, category, reportDate, title, tags, setIsGuideModalOpen } = props;
   const { lockScroll } = useBodyScrollLock();
+
+  const handleGuideModalOpen = () => {
+    lockScroll();
+    setIsGuideModalOpen(true);
+  };
 
   return (
     <StVideoDetail>
@@ -31,13 +36,7 @@ function VideoDetail(props: VideoDetailProps) {
         </StTagContainer>
       </StLeft>
       <StRight>
-        <button
-          onClick={() => {
-            lockScroll();
-            setIsModalOpen(true);
-          }}>
-          어떻게 학습하나요?
-        </button>
+        <button onClick={handleGuideModalOpen}>어떻게 학습하나요?</button>
       </StRight>
     </StVideoDetail>
   );

--- a/src/components/learnDetail/VideoDetail.tsx
+++ b/src/components/learnDetail/VideoDetail.tsx
@@ -2,6 +2,7 @@ import { Tag } from '@src/services/api/types/learn-detail';
 import styled from 'styled-components';
 import { COLOR } from '@src/styles/color';
 import { FONT_STYLES } from '@src/styles/fontStyle';
+import { useBodyScrollLock } from '@src/hooks/useBodyScrollLock';
 
 interface VideoDetailProps {
   channel: string;
@@ -14,6 +15,7 @@ interface VideoDetailProps {
 
 function VideoDetail(props: VideoDetailProps) {
   const { channel, category, reportDate, title, tags, setIsModalOpen } = props;
+  const { lockScroll } = useBodyScrollLock();
 
   return (
     <StVideoDetail>
@@ -29,7 +31,13 @@ function VideoDetail(props: VideoDetailProps) {
         </StTagContainer>
       </StLeft>
       <StRight>
-        <button onClick={() => setIsModalOpen(true)}>어떻게 학습하나요?</button>
+        <button
+          onClick={() => {
+            lockScroll();
+            setIsModalOpen(true);
+          }}>
+          어떻게 학습하나요?
+        </button>
       </StRight>
     </StVideoDetail>
   );

--- a/src/hooks/useBodyScrollLock.ts
+++ b/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,13 @@
+import { useCallback } from 'react';
+
+export function useBodyScrollLock() {
+  const lockScroll = useCallback(() => {
+    document.body.style.overflow = 'hidden';
+  }, []);
+
+  const unlockScroll = useCallback(() => {
+    document.body.style.removeProperty('overflow');
+  }, []);
+
+  return { lockScroll, unlockScroll };
+}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -42,6 +42,7 @@ export default class MyDocument extends Document {
         </Head>
         <body>
           <Main />
+          <div id="portal" />
           <NextScript />
         </body>
       </Html>

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { useMutation, useQuery } from 'react-query';
 import { useRecoilState, useRecoilValue } from 'recoil';
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
 import YouTube from 'react-youtube';
 import VideoListSkeleton from '@src/components/common/VideoListSkeleton';
 import Portal from '@src/components/common/Portal';
@@ -38,8 +40,7 @@ import {
   CONTEXT_MENU_WIDTH,
   ABSOLUTE_RIGHT_LIMIT,
 } from '@src/utils/constant';
-import dynamic from 'next/dynamic';
-import { useRouter } from 'next/router';
+import { useBodyScrollLock } from '@src/hooks/useBodyScrollLock';
 import {
   icHighlighterClicked,
   icHighlighterDefault,
@@ -72,6 +73,7 @@ function LearnDetail() {
   const isLoggedIn = useRecoilValue(loginState);
   const [videoData, setVideoData] = useState<VideoData>();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const { unlockScroll } = useBodyScrollLock();
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
   const [confirmModalText, setConfirmModalText] = useState<ConfirmModalText>(NEW_MEMO_CONFIRM_MODAL_TEXT);
   const [isHighlight, setIsHighlight] = useState(false);
@@ -761,7 +763,12 @@ function LearnDetail() {
         )}
         {isModalOpen && (
           <Portal selector="#portal">
-            <GuideModal closeModal={() => setIsModalOpen(false)} />
+            <GuideModal
+              closeModal={() => {
+                unlockScroll();
+                setIsModalOpen(false);
+              }}
+            />
           </Portal>
         )}
         {isConfirmOpen && (

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -1,6 +1,14 @@
+import React, { useEffect, useRef, useState } from 'react';
+import styled, { css } from 'styled-components';
+import { useMutation, useQuery } from 'react-query';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import YouTube from 'react-youtube';
+import VideoListSkeleton from '@src/components/common/VideoListSkeleton';
+import Portal from '@src/components/common/Portal';
 import ImageDiv from '@src/components/common/ImageDiv';
 import Like from '@src/components/common/Like';
 import SEO from '@src/components/common/SEO';
+import NewsList from '@src/components/common/NewsList';
 import ConfirmModal, { ConfirmModalText } from '@src/components/learnDetail/ConfirmModal';
 import ContextMenu from '@src/components/learnDetail/ContextMenu';
 import GuideModal from '@src/components/learnDetail/GuideModal';
@@ -14,7 +22,9 @@ import RecordStatusBar from '@src/components/learnDetail/record/RecordStatusBar'
 import RecordLog from '@src/components/learnDetail/record/RecordLog';
 import { api } from '@src/services/api';
 import { MemoData, Name, VideoData } from '@src/services/api/types/learn-detail';
+import { VideoData as simpleVideoData } from '@src/services/api/types/home';
 import { loginState } from '@src/stores/loginState';
+import { isGuideAtom } from '@src/stores/newsState';
 import { COLOR } from '@src/styles/color';
 import { FONT_STYLES } from '@src/styles/fontStyle';
 import {
@@ -40,15 +50,6 @@ import {
   icSpeechGuideInfo,
   icXButton,
 } from 'public/assets/icons';
-import React, { useEffect, useRef, useState } from 'react';
-import YouTube from 'react-youtube';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import styled, { css } from 'styled-components';
-import { useMutation, useQuery } from 'react-query';
-import { isGuideAtom } from '@src/stores/newsState';
-import NewsList from '@src/components/common/NewsList';
-import { VideoData as simpleVideoData } from '@src/services/api/types/home';
-import VideoListSkeleton from '@src/components/common/VideoListSkeleton';
 
 export interface MemoState {
   newMemoId: number;
@@ -758,7 +759,11 @@ function LearnDetail() {
             )}
           </StNews>
         )}
-        {isModalOpen && <GuideModal closeModal={() => setIsModalOpen(false)} />}
+        {isModalOpen && (
+          <Portal selector="#portal">
+            <GuideModal closeModal={() => setIsModalOpen(false)} />
+          </Portal>
+        )}
         {isConfirmOpen && (
           <ConfirmModal
             confirmModalText={confirmModalText}

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -813,6 +813,10 @@ const StLearnDetail = styled.div`
     width: 4.8rem;
     height: 4.8rem;
     cursor: pointer;
+
+    @media (max-width: 1280px) {
+      display: none;
+    }
   }
 `;
 

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -72,7 +72,7 @@ function LearnDetail() {
   const [isGuide, setIsGuide] = useRecoilState(isGuideAtom);
   const isLoggedIn = useRecoilValue(loginState);
   const [videoData, setVideoData] = useState<VideoData>();
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isGuideModalOpen, setIsGuideModalOpen] = useState(false);
   const { unlockScroll } = useBodyScrollLock();
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
   const [confirmModalText, setConfirmModalText] = useState<ConfirmModalText>(NEW_MEMO_CONFIRM_MODAL_TEXT);
@@ -544,7 +544,7 @@ function LearnDetail() {
         </StScriptTitleContainer>
         {videoData && (
           <StLearnBox isGuide={isGuide}>
-            <VideoDetail {...videoData} setIsModalOpen={setIsModalOpen} />
+            <VideoDetail {...videoData} setIsGuideModalOpen={setIsGuideModalOpen} />
             <main>
               <StLearnSection isGuide={isGuide}>
                 <article>
@@ -761,12 +761,12 @@ function LearnDetail() {
             )}
           </StNews>
         )}
-        {isModalOpen && (
+        {isGuideModalOpen && (
           <Portal selector="#portal">
             <GuideModal
               closeModal={() => {
                 unlockScroll();
-                setIsModalOpen(false);
+                setIsGuideModalOpen(false);
               }}
             />
           </Portal>


### PR DESCRIPTION
## 🚩 관련 이슈
- close #176 

## 📋 작업 내용
- [x] 창 크기 줄어든 상태에서는 X 버튼 안 보이도록 수정
- [x] 학습 기능 설명 모달 위치 수정

## 📌 PR Point
- `Portal`을 적용해 학습 기능 설명 모달(GuideModal)을 리팩토링 했습니다.
  참고한 글 : [Portal 사용법 (nextjs, cra)](https://kyounghwan01.github.io/blog/React/next/use-portal/#cra%E1%84%8B%E1%85%A6%E1%84%89%E1%85%A5-portal-%E1%84%89%E1%85%A1%E1%84%8B%E1%85%AD%E1%86%BC%E1%84%92%E1%85%A1%E1%84%80%E1%85%B5)
- `useBodyScrollLock`이라는 훅을 만들었습니다. 모달이 나타나면 스크롤을 막고, 모달을 닫으면 다시 풀어주는 역할을 합니다.
- [id].tsx의 import 구문들을 관련된 것들끼리 모아뒀습니다. (stores, types, common component ..)

## 📸 스크린샷
|x 버튼 안 보이도록 수정|모달 위치 수정|
|:-:|:-:|
|![image](https://user-images.githubusercontent.com/58380158/210224952-7afb8960-c71e-4b14-9a2f-f7e6358cfdd5.png)|![image](https://user-images.githubusercontent.com/58380158/210224847-44b6b59c-5bc7-48d2-85e2-ec93ef1be208.png)|