### PR TITLE
[common] API 통신 리팩터링

### DIFF
--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -13,12 +13,12 @@ import { useQuery } from 'react-query';
 import { useMediaQuery } from 'react-responsive';
 import styled from 'styled-components';
 import { loginState } from '@src/stores/loginState';
-import { useRecoilState } from 'recoil';
 import { useRouter } from 'next/router';
+import { useSetRecoilState } from 'recoil';
 
 function Home() {
   const router = useRouter();
-  const [isLoggedIn, setIsLoggedIn] = useRecoilState(loginState);
+  const setIsLoggedIn = useSetRecoilState(loginState);
   const [newsList, setNewsList] = useState<VideoData[]>([]);
   const [speechGuideList, setSpeechGuideList] = useState<VideoData[]>([]);
   const [mounted, setMounted] = useState(false);
@@ -34,12 +34,8 @@ function Home() {
     ['getNewsList'],
     async () => {
       return {
-        recommend: isLoggedIn
-          ? await api.homeService.getPrivateVideoData()
-          : await api.homeService.getPublicVideoData(),
-        speechGuide: isLoggedIn
-          ? await api.homeService.getPrivateSpeechGuideData()
-          : await api.homeService.getPublicSpeechGuideData(),
+        recommend: await api.homeService.getVideoData(),
+        speechGuide: await api.homeService.getSpeechGuideData(),
       };
     },
     {

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -443,9 +443,7 @@ function LearnDetail() {
       const id = Number(detailId);
       let data;
       if (isGuide) {
-        data = isLoggedIn
-          ? await api.learnDetailService.getPrivateSpeechGuideData(id)
-          : await api.learnDetailService.getPublicSpeechGuideData(id);
+        data = await api.learnDetailService.getSpeechGuideData(id);
       } else {
         data = isLoggedIn
           ? await api.learnDetailService.getPrivateVideoData(id, clickedScriptTitleIndex)

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -459,6 +459,10 @@ function LearnDetail() {
   }, [isLoggedIn, detailId, isEditing, isGuide, clickedScriptTitleIndex]);
 
   useEffect(() => {
+    setClickedScriptTitleIndex(0);
+  }, [detailId]);
+
+  useEffect(() => {
     if (!player) return;
 
     const interval =

--- a/src/pages/learn/index.tsx
+++ b/src/pages/learn/index.tsx
@@ -15,13 +15,13 @@ import { BLOCK_SIZE, categoryList, channelList, LIST_SIZE, speakerList } from '@
 import { icSearch } from 'public/assets/icons';
 import { useEffect, useState } from 'react';
 import { useMutation } from 'react-query';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 import { useRouter } from 'next/router';
 
 function Learn() {
   const router = useRouter();
-  const [isLoggedIn, setIsLoggedIn] = useRecoilState(loginState);
+  const setIsLoggedIn = useSetRecoilState(loginState);
   const [selectedChannelList, setSelectedChannelList] = useState<string[]>([]);
   const [selectedCategoryList, setSelectedCategoryList] = useState<string[]>([]);
   const [selectedSpeakerList, setSelectedSpeakerList] = useState<string[]>([]);
@@ -32,9 +32,7 @@ function Learn() {
 
   const { mutate, isLoading } = useMutation(
     async (requestBody: PostSearchConditionRequestBody) => {
-      return isLoggedIn
-        ? await api.learnService.postSearchConditionWithToken(requestBody)
-        : await api.learnService.postSearchConditionWithoutToken(requestBody);
+      return await api.learnService.postSearchCondition(requestBody);
     },
     {
       onSuccess: (data) => {

--- a/src/services/api/home.ts
+++ b/src/services/api/home.ts
@@ -1,8 +1,6 @@
 import { VideoListData } from './types/home';
 
 export interface HomeService {
-  getPrivateVideoData(): Promise<VideoListData>;
-  getPublicVideoData(): Promise<VideoListData>;
-  getPrivateSpeechGuideData(): Promise<VideoListData>;
-  getPublicSpeechGuideData(): Promise<VideoListData>;
+  getVideoData(): Promise<VideoListData>;
+  getSpeechGuideData(): Promise<VideoListData>;
 }

--- a/src/services/api/learn-detail.ts
+++ b/src/services/api/learn-detail.ts
@@ -13,7 +13,7 @@ import {
 } from './types/learn-detail';
 
 export interface LearnDetailService {
-  getPrivateVideoData(videoId: number, index?: number): Promise<VideoData>;
+  getPrivateVideoData(videoId: number, index: number): Promise<VideoData>;
   getPublicVideoData(videoId: number): Promise<VideoData>;
   postSentenceData(SentenceData: SentenceData, scriptsId: number, scriptIndex: number): Promise<VideoData>;
   postMemoData(memo: MemoData, scriptId: number): Promise<MemoData[]>;

--- a/src/services/api/learn-detail.ts
+++ b/src/services/api/learn-detail.ts
@@ -22,8 +22,7 @@ export interface LearnDetailService {
   postNewScriptData(videoId: number): Promise<{ isSuccess: boolean }>;
   deleteScriptData(scriptId: number): Promise<{ isSuccess: boolean }>;
   updateScriptNameData(scriptId: number, name: string): Promise<Name>;
-  getPublicSpeechGuideData(videoId: number): Promise<VideoData>;
-  getPrivateSpeechGuideData(videoId: number): Promise<VideoData>;
+  getSpeechGuideData(videoId: number): Promise<VideoData>;
   uploadRecordData(body: UploadRecordData): Promise<UploadRecordResponse>;
   getRecordData(scriptId: number): Promise<GetRecordData[]>;
   deleteRecordData(body: DeleteRecordData): Promise<DeleteRecordResponse>;

--- a/src/services/api/learn.ts
+++ b/src/services/api/learn.ts
@@ -1,6 +1,5 @@
 import { PostSearchConditionRequestBody, PostSearchConditionResponse } from './types/learn';
 
 export interface LearnService {
-  postSearchConditionWithToken(body: PostSearchConditionRequestBody): Promise<PostSearchConditionResponse>;
-  postSearchConditionWithoutToken(body: PostSearchConditionRequestBody): Promise<PostSearchConditionResponse>;
+  postSearchCondition(body: PostSearchConditionRequestBody): Promise<PostSearchConditionResponse>;
 }

--- a/src/services/mock/home.ts
+++ b/src/services/mock/home.ts
@@ -2,24 +2,16 @@ import { HomeService } from '../api/home';
 import { HOME_DATA } from './home.data';
 
 export function homeDataMock(): HomeService {
-  const getPrivateVideoData = async () => {
+  const getVideoData = async () => {
     await wait(500);
     return HOME_DATA;
   };
-  const getPublicVideoData = async () => {
-    await wait(500);
-    return HOME_DATA;
-  };
-  const getPublicSpeechGuideData = async () => {
-    await wait(500);
-    return HOME_DATA;
-  };
-  const getPrivateSpeechGuideData = async () => {
+  const getSpeechGuideData = async () => {
     await wait(500);
     return HOME_DATA;
   };
 
-  return { getPrivateVideoData, getPublicVideoData, getPublicSpeechGuideData, getPrivateSpeechGuideData };
+  return { getVideoData, getSpeechGuideData };
 }
 
 const wait = (milliSeconds: number) => new Promise((resolve) => setTimeout(resolve, milliSeconds));

--- a/src/services/mock/learn-detail.ts
+++ b/src/services/mock/learn-detail.ts
@@ -48,12 +48,7 @@ export function learnDetailDataMock(): LearnDetailService {
     return LEARN_DETAIL_DATA.NAME_DATA;
   };
 
-  const getPrivateSpeechGuideData = async () => {
-    await wait(500);
-    return LEARN_DETAIL_DATA.VIDEO_DATA;
-  };
-
-  const getPublicSpeechGuideData = async () => {
+  const getSpeechGuideData = async () => {
     await wait(500);
     return LEARN_DETAIL_DATA.VIDEO_DATA;
   };
@@ -93,8 +88,7 @@ export function learnDetailDataMock(): LearnDetailService {
     postNewScriptData,
     deleteScriptData,
     updateScriptNameData,
-    getPrivateSpeechGuideData,
-    getPublicSpeechGuideData,
+    getSpeechGuideData,
     uploadRecordData,
     getRecordData,
     deleteRecordData,

--- a/src/services/mock/learn.ts
+++ b/src/services/mock/learn.ts
@@ -2,17 +2,12 @@ import { LearnService } from '../api/learn';
 import { LEARN_DATA } from './learn.data';
 
 export function learnDataMock(): LearnService {
-  const postSearchConditionWithToken = async () => {
+  const postSearchCondition = async () => {
     await wait(500);
     return LEARN_DATA.VIDEO_LIST_DATA;
   };
 
-  const postSearchConditionWithoutToken = async () => {
-    await wait(500);
-    return LEARN_DATA.VIDEO_LIST_DATA;
-  };
-
-  return { postSearchConditionWithToken, postSearchConditionWithoutToken };
+  return { postSearchCondition };
 }
 
 const wait = (milliSeconds: number) => new Promise((resolve) => setTimeout(resolve, milliSeconds));

--- a/src/services/remote/base.ts
+++ b/src/services/remote/base.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 const BASEURL = 'https://deliverble.online';
 const getAccessToken = () => localStorage.getItem('token') ?? '';
 
-const getBasePrivateHeaders = () => {
+const getBaseHeaders = () => {
   const accessToken = getAccessToken();
   const headers = {
     Accept: `*/*`,
@@ -19,22 +19,11 @@ const getBasePrivateHeaders = () => {
   return headers;
 };
 
-const getBasePrivateMultipartHeaders = () => {
-  const accessToken = getAccessToken();
-  const headers = {
-    Accept: `*/*`,
-    'Content-Type': `multipart/form-data`,
-  };
-
-  if (accessToken) {
-    return {
-      ...headers,
-      Authorization: `Bearer ${accessToken}`,
-    };
-  }
-
-  return headers;
-};
+const getBasePrivateMultipartHeaders = () => ({
+  Accept: `*/*`,
+  'Content-Type': `multipart/form-data`,
+  Authorization: `Bearer ${getAccessToken()}`,
+});
 
 interface Request {
   url: string;
@@ -52,7 +41,7 @@ interface RequestWithData extends Request {
 }
 
 const sendRequest = ({ url, params, method, headers }: RequestWithParams) => {
-  const baseHeaders = getBasePrivateHeaders();
+  const baseHeaders = getBaseHeaders();
   return axios[method](BASEURL + url, {
     headers: { ...baseHeaders, ...headers },
     params,
@@ -62,7 +51,7 @@ const sendRequest = ({ url, params, method, headers }: RequestWithParams) => {
 };
 
 const sendRequestForData = ({ url, data, method, headers, type }: RequestWithData) => {
-  const baseHeaders = type === 'json' ? getBasePrivateHeaders() : getBasePrivateMultipartHeaders();
+  const baseHeaders = type === 'json' ? getBaseHeaders() : getBasePrivateMultipartHeaders();
   return axios[method](BASEURL + url, data, {
     headers: { ...baseHeaders, ...headers },
   }).then((response) => {
@@ -71,7 +60,7 @@ const sendRequestForData = ({ url, data, method, headers, type }: RequestWithDat
 };
 
 const sendRequestForDelete = ({ url, data, headers }: Omit<RequestWithData, 'method'>) => {
-  const baseHeaders = getBasePrivateHeaders();
+  const baseHeaders = getBaseHeaders();
   return axios
     .delete(BASEURL + url, {
       headers: { ...baseHeaders, ...headers },

--- a/src/services/remote/base.ts
+++ b/src/services/remote/base.ts
@@ -92,7 +92,7 @@ const sendRequestForDelete = ({ url, data, headers, isPrivate }: Omit<RequestWit
     });
 };
 
-export const privateAPI = {
+export const API = {
   get: ({ url, params, headers }: Omit<RequestWithParams, 'isPrivate' | 'method'>) =>
     sendRequest({ url, params, method: 'get', headers, isPrivate: true }),
   post: ({ url, data, headers, type }: Omit<RequestWithData, 'isPrivate' | 'method'>) =>
@@ -119,33 +119,5 @@ export const privateAPI = {
       data,
       headers,
       isPrivate: true,
-    }),
-};
-
-export const publicAPI = {
-  get: ({ url, params, headers }: Omit<RequestWithParams, 'isPrivate' | 'method'>) =>
-    sendRequest({ url, params, method: 'get', headers, isPrivate: false }),
-  post: ({ url, data, headers }: Omit<RequestWithData, 'isPrivate' | 'method'>) =>
-    sendRequestForData({
-      url,
-      data,
-      method: 'post',
-      headers,
-      isPrivate: false,
-    }),
-  patch: ({ url, data, headers }: Omit<RequestWithData, 'isPrivate' | 'method'>) =>
-    sendRequestForData({
-      url,
-      data,
-      method: 'patch',
-      headers,
-      isPrivate: false,
-    }),
-  delete: ({ url, data, headers }: Omit<RequestWithData, 'isPrivate' | 'method'>) =>
-    sendRequestForDelete({
-      url,
-      data,
-      headers,
-      isPrivate: false,
     }),
 };

--- a/src/services/remote/base.ts
+++ b/src/services/remote/base.ts
@@ -19,11 +19,6 @@ const getBasePrivateHeaders = () => {
   return headers;
 };
 
-const basePublicHeaders = {
-  Accept: `*/*`,
-  'Content-Type': `application/json`,
-};
-
 const getBasePrivateMultipartHeaders = () => {
   const accessToken = getAccessToken();
   const headers = {
@@ -44,7 +39,6 @@ const getBasePrivateMultipartHeaders = () => {
 interface Request {
   url: string;
   headers?: object;
-  isPrivate: boolean;
   method: 'get' | 'post' | 'patch' | 'delete';
 }
 
@@ -57,8 +51,8 @@ interface RequestWithData extends Request {
   type?: 'json' | 'multipart';
 }
 
-const sendRequest = ({ url, params, method, headers, isPrivate }: RequestWithParams) => {
-  const baseHeaders = isPrivate ? getBasePrivateHeaders() : basePublicHeaders;
+const sendRequest = ({ url, params, method, headers }: RequestWithParams) => {
+  const baseHeaders = getBasePrivateHeaders();
   return axios[method](BASEURL + url, {
     headers: { ...baseHeaders, ...headers },
     params,
@@ -67,12 +61,8 @@ const sendRequest = ({ url, params, method, headers, isPrivate }: RequestWithPar
   });
 };
 
-const sendRequestForData = ({ url, data, method, headers, isPrivate, type }: RequestWithData) => {
-  const baseHeaders = isPrivate
-    ? type === 'json'
-      ? getBasePrivateHeaders()
-      : getBasePrivateMultipartHeaders()
-    : basePublicHeaders;
+const sendRequestForData = ({ url, data, method, headers, type }: RequestWithData) => {
+  const baseHeaders = type === 'json' ? getBasePrivateHeaders() : getBasePrivateMultipartHeaders();
   return axios[method](BASEURL + url, data, {
     headers: { ...baseHeaders, ...headers },
   }).then((response) => {
@@ -80,8 +70,8 @@ const sendRequestForData = ({ url, data, method, headers, isPrivate, type }: Req
   });
 };
 
-const sendRequestForDelete = ({ url, data, headers, isPrivate }: Omit<RequestWithData, 'method'>) => {
-  const baseHeaders = isPrivate ? getBasePrivateHeaders() : basePublicHeaders;
+const sendRequestForDelete = ({ url, data, headers }: Omit<RequestWithData, 'method'>) => {
+  const baseHeaders = getBasePrivateHeaders();
   return axios
     .delete(BASEURL + url, {
       headers: { ...baseHeaders, ...headers },
@@ -93,31 +83,28 @@ const sendRequestForDelete = ({ url, data, headers, isPrivate }: Omit<RequestWit
 };
 
 export const API = {
-  get: ({ url, params, headers }: Omit<RequestWithParams, 'isPrivate' | 'method'>) =>
-    sendRequest({ url, params, method: 'get', headers, isPrivate: true }),
-  post: ({ url, data, headers, type }: Omit<RequestWithData, 'isPrivate' | 'method'>) =>
+  get: ({ url, params, headers }: Omit<RequestWithParams, 'method'>) =>
+    sendRequest({ url, params, method: 'get', headers }),
+  post: ({ url, data, headers, type }: Omit<RequestWithData, 'method'>) =>
     sendRequestForData({
       url,
       data,
       method: 'post',
       headers,
-      isPrivate: true,
       type: type ?? 'json',
     }),
-  patch: ({ url, data, headers, type }: Omit<RequestWithData, 'isPrivate' | 'method'>) =>
+  patch: ({ url, data, headers, type }: Omit<RequestWithData, 'method'>) =>
     sendRequestForData({
       url,
       data,
       method: 'patch',
       headers,
       type: type ?? 'json',
-      isPrivate: true,
     }),
-  delete: ({ url, data, headers }: Omit<RequestWithData, 'isPrivate' | 'method'>) =>
+  delete: ({ url, data, headers }: Omit<RequestWithData, 'method'>) =>
     sendRequestForDelete({
       url,
       data,
       headers,
-      isPrivate: true,
     }),
 };

--- a/src/services/remote/home.ts
+++ b/src/services/remote/home.ts
@@ -1,10 +1,10 @@
 import { VideoData } from '../api/types/home';
 import { HomeService } from './../api/home';
-import { privateAPI, publicAPI } from './base';
+import { API } from './base';
 
 export function homeDataRemote(): HomeService {
-  const getPrivateVideoData = async () => {
-    const response = await privateAPI.get({ url: `/news/recommend` });
+  const getVideoData = async () => {
+    const response = await API.get({ url: `/news/recommend` });
     if (response.statusCode === 200) {
       return {
         videoList: response.data
@@ -23,27 +23,8 @@ export function homeDataRemote(): HomeService {
     } else throw '서버 통신 실패';
   };
 
-  const getPublicVideoData = async () => {
-    const response = await publicAPI.get({ url: `/news/recommend` });
-    if (response.statusCode === 200) {
-      return {
-        videoList: response.data
-          ? response.data.exploreNewsDtoCollection.map((video: VideoData) => ({
-              id: video.id,
-              title: video.title,
-              category: video.category,
-              channel: video.channel,
-              thumbnail: video.thumbnail,
-              reportDate: video.reportDate,
-              haveGuide: video.haveGuide,
-            }))
-          : [],
-      };
-    } else throw '서버 통신 실패';
-  };
-
-  const getPrivateSpeechGuideData = async () => {
-    const response = await privateAPI.get({ url: `/news/guide` });
+  const getSpeechGuideData = async () => {
+    const response = await API.get({ url: `/news/guide` });
     if (response.statusCode === 200) {
       return {
         videoList: response.data
@@ -62,24 +43,5 @@ export function homeDataRemote(): HomeService {
     } else throw '서버 통신 실패';
   };
 
-  const getPublicSpeechGuideData = async () => {
-    const response = await publicAPI.get({ url: `/news/guide` });
-    if (response.statusCode === 200) {
-      return {
-        videoList: response.data
-          ? response.data.exploreNewsDtoCollection.map((video: VideoData) => ({
-              id: video.id,
-              title: video.title,
-              category: video.category,
-              channel: video.channel,
-              thumbnail: video.thumbnail,
-              reportDate: video.reportDate,
-              haveGuide: video.haveGuide,
-            }))
-          : [],
-      };
-    } else throw '서버 통신 실패';
-  };
-
-  return { getPrivateVideoData, getPublicVideoData, getPrivateSpeechGuideData, getPublicSpeechGuideData };
+  return { getVideoData, getSpeechGuideData };
 }

--- a/src/services/remote/learn-detail.ts
+++ b/src/services/remote/learn-detail.ts
@@ -14,7 +14,7 @@ import { VideoData } from '../api/types/home';
 import { API } from './base';
 
 export function learnDetailDataRemote(): LearnDetailService {
-  const getPrivateVideoData = async (videoId: number, index?: number) => {
+  const getPrivateVideoData = async (videoId: number, index: number) => {
     const response = await API.get({ url: `/news/detail/${videoId}` });
     if (response.statusCode === 200) {
       return {

--- a/src/services/remote/learn-detail.ts
+++ b/src/services/remote/learn-detail.ts
@@ -17,6 +17,7 @@ export function learnDetailDataRemote(): LearnDetailService {
   const getPrivateVideoData = async (videoId: number, index: number) => {
     const response = await API.get({ url: `/news/detail/${videoId}` });
     if (response.statusCode === 200) {
+      const scriptIndex = response.data2[index] ? index : 0;
       return {
         id: response.data.id,
         title: response.data.title,
@@ -28,19 +29,19 @@ export function learnDetailDataRemote(): LearnDetailService {
         haveGuide: response.data.haveGuide,
         startTime: response.data.startTime,
         endTime: response.data.endTime,
-        scriptsId: response.data2[index ?? 0].id,
+        scriptsId: response.data2[scriptIndex].id,
         tags: response.data.tagsForView.map((tag: Tag) => ({
           id: tag.id,
           name: tag.name,
         })),
-        scripts: response.data2[index ?? 0].sentences.map((sentence: Script) => ({
+        scripts: response.data2[scriptIndex].sentences.map((sentence: Script) => ({
           id: sentence.id,
           order: sentence.order,
           text: sentence.text,
           startTime: sentence.startTime,
           endTime: sentence.endTime,
         })),
-        memos: response.data2[index ?? 0].memos.map((memo: MemoData) => ({
+        memos: response.data2[scriptIndex].memos.map((memo: MemoData) => ({
           id: memo.id,
           keyword: memo.keyword,
           order: memo.order,

--- a/src/services/remote/learn-detail.ts
+++ b/src/services/remote/learn-detail.ts
@@ -11,11 +11,11 @@ import {
   ChangeRecordNameData,
 } from '../api/types/learn-detail';
 import { VideoData } from '../api/types/home';
-import { privateAPI, publicAPI } from './base';
+import { API } from './base';
 
 export function learnDetailDataRemote(): LearnDetailService {
   const getPrivateVideoData = async (videoId: number, index?: number) => {
-    const response = await privateAPI.get({ url: `/news/detail/${videoId}` });
+    const response = await API.get({ url: `/news/detail/${videoId}` });
     if (response.statusCode === 200) {
       return {
         id: response.data.id,
@@ -57,7 +57,7 @@ export function learnDetailDataRemote(): LearnDetailService {
   };
 
   const getPublicVideoData = async (videoId: number) => {
-    const response = await publicAPI.get({ url: `/news/detail/not-authentication/${videoId}` });
+    const response = await API.get({ url: `/news/detail/not-authentication/${videoId}` });
     if (response.statusCode === 200) {
       return {
         id: response.data.id,
@@ -86,46 +86,8 @@ export function learnDetailDataRemote(): LearnDetailService {
     } else throw '서버 통신 실패';
   };
 
-  const getPublicSpeechGuideData = async (videoId: number) => {
-    const response = await publicAPI.get({ url: `/news/guide/detail/${videoId}` });
-    if (response.statusCode === 200) {
-      return {
-        id: response.data.id,
-        title: response.data.title,
-        category: response.data.category,
-        channel: response.data.channel,
-        link: response.data.link,
-        reportDate: response.data.reportDate,
-        isFavorite: response.data.isFavorite,
-        haveGuide: response.data.haveGuide,
-        startTime: response.data.startTime,
-        endTime: response.data.endTime,
-        scriptsId: response.data2[0].id,
-        tags: response.data.tagsForView.map((tag: Tag) => ({
-          id: tag.id,
-          name: tag.name,
-        })),
-        scripts: response.data2[0].sentences.map((sentence: Script) => ({
-          id: sentence.id,
-          text: sentence.text,
-          order: sentence.order,
-          startTime: sentence.startTime,
-          endTime: sentence.endTime,
-        })),
-        memos: response.data2[0].memoGuides.map((memo: MemoData) => ({
-          id: memo.id,
-          keyword: memo.keyword,
-          order: memo.order,
-          startIndex: memo.startIndex,
-          content: memo.content,
-          highlightId: memo.highlightId,
-        })),
-      };
-    } else throw '서버 통신 실패';
-  };
-
-  const getPrivateSpeechGuideData = async (videoId: number) => {
-    const response = await privateAPI.get({ url: `/news/guide/detail/${videoId}` });
+  const getSpeechGuideData = async (videoId: number) => {
+    const response = await API.get({ url: `/news/guide/detail/${videoId}` });
     if (response.statusCode === 200) {
       return {
         id: response.data.id,
@@ -163,7 +125,7 @@ export function learnDetailDataRemote(): LearnDetailService {
   };
 
   const postSentenceData = async (SentenceData: SentenceData, scriptsId: number, scriptIndex: number) => {
-    const response = await privateAPI.post({
+    const response = await API.post({
       url: `/script/sentence/update/${scriptsId}`,
       data: SentenceData,
     });
@@ -178,7 +140,7 @@ export function learnDetailDataRemote(): LearnDetailService {
   };
 
   const postMemoData = async (memo: MemoData, scriptId: number) => {
-    const response = await privateAPI.post({
+    const response = await API.post({
       url: `/script/memo/create/${scriptId}`,
       data: memo,
     });
@@ -195,7 +157,7 @@ export function learnDetailDataRemote(): LearnDetailService {
   };
 
   const updateMemoData = async (memoId: number, content: string) => {
-    const response = await privateAPI.patch({
+    const response = await API.patch({
       url: `/script/memo/update/${memoId}`,
       data: { content },
     });
@@ -212,7 +174,7 @@ export function learnDetailDataRemote(): LearnDetailService {
   };
 
   const deleteMemoData = async (memoId: number) => {
-    const response = await privateAPI.delete({
+    const response = await API.delete({
       url: `/script/memo/delete/${memoId}`,
     });
     if (response.statusCode === 200) {
@@ -228,17 +190,17 @@ export function learnDetailDataRemote(): LearnDetailService {
   };
 
   const postNewScriptData = async (videoId: number) => {
-    const response = await privateAPI.post({ url: `/script/create/${videoId}` });
+    const response = await API.post({ url: `/script/create/${videoId}` });
     return { isSuccess: response.statusCode === 200 };
   };
 
   const deleteScriptData = async (scriptId: number) => {
-    const response = await privateAPI.delete({ url: `/script/delete/${scriptId}` });
+    const response = await API.delete({ url: `/script/delete/${scriptId}` });
     return { isSuccess: response.statusCode === 200 };
   };
 
   const updateScriptNameData = async (scriptId: number, name: string) => {
-    const response = await privateAPI.patch({ url: `/script/name/${scriptId}`, data: { name } });
+    const response = await API.patch({ url: `/script/name/${scriptId}`, data: { name } });
     if (response.statusCode === 200) {
       return {
         id: response.data2.id,
@@ -248,7 +210,7 @@ export function learnDetailDataRemote(): LearnDetailService {
   };
 
   const uploadRecordData = async (body: UploadRecordData) => {
-    const response = await privateAPI.post({
+    const response = await API.post({
       url: '/script/recording/upload',
       data: body,
       type: 'multipart',
@@ -265,7 +227,7 @@ export function learnDetailDataRemote(): LearnDetailService {
 
   const getRecordData = async (scriptId: number) => {
     try {
-      const response = await privateAPI.get({
+      const response = await API.get({
         url: `/script/recording/find?scriptId=${scriptId}`,
       });
       return response.data[0].map((record: GetRecordData) => ({
@@ -282,7 +244,7 @@ export function learnDetailDataRemote(): LearnDetailService {
   };
 
   const deleteRecordData = async (body: DeleteRecordData) => {
-    const response = await privateAPI.post({
+    const response = await API.post({
       url: '/script/recording/delete',
       data: body,
     });
@@ -296,7 +258,7 @@ export function learnDetailDataRemote(): LearnDetailService {
   };
 
   const changeRecordNameData = async (body: ChangeRecordNameData) => {
-    const response = await privateAPI.post({
+    const response = await API.post({
       url: '/script/recording/change-name',
       data: body,
     });
@@ -310,7 +272,7 @@ export function learnDetailDataRemote(): LearnDetailService {
   };
 
   const getSimilarVideoData = async (videoId: number) => {
-    const response = await privateAPI.get({
+    const response = await API.get({
       url: `/news/similar/${videoId}`,
     });
     if (response.statusCode === 200) {
@@ -341,8 +303,7 @@ export function learnDetailDataRemote(): LearnDetailService {
     postNewScriptData,
     deleteScriptData,
     updateScriptNameData,
-    getPublicSpeechGuideData,
-    getPrivateSpeechGuideData,
+    getSpeechGuideData,
     uploadRecordData,
     getRecordData,
     deleteRecordData,

--- a/src/services/remote/learn.ts
+++ b/src/services/remote/learn.ts
@@ -1,10 +1,10 @@
 import { LearnService } from '../api/learn';
-import { privateAPI, publicAPI } from './base';
+import { API } from './base';
 import { PostSearchConditionRequestBody, VideoData } from '../api/types/learn';
 
 export function learnDataRemote(): LearnService {
   const postSearchConditionWithToken = async (body: PostSearchConditionRequestBody) => {
-    const response = await privateAPI.post({
+    const response = await API.post({
       url: `/news/search`,
       data: body,
     });
@@ -29,7 +29,7 @@ export function learnDataRemote(): LearnService {
   };
 
   const postSearchConditionWithoutToken = async (body: PostSearchConditionRequestBody) => {
-    const response = await publicAPI.post({
+    const response = await API.post({
       url: `/news/search`,
       data: body,
     });

--- a/src/services/remote/learn.ts
+++ b/src/services/remote/learn.ts
@@ -3,7 +3,7 @@ import { API } from './base';
 import { PostSearchConditionRequestBody, VideoData } from '../api/types/learn';
 
 export function learnDataRemote(): LearnService {
-  const postSearchConditionWithToken = async (body: PostSearchConditionRequestBody) => {
+  const postSearchCondition = async (body: PostSearchConditionRequestBody) => {
     const response = await API.post({
       url: `/news/search`,
       data: body,
@@ -28,29 +28,5 @@ export function learnDataRemote(): LearnService {
     };
   };
 
-  const postSearchConditionWithoutToken = async (body: PostSearchConditionRequestBody) => {
-    const response = await API.post({
-      url: `/news/search`,
-      data: body,
-    });
-    return {
-      videoList: response.data
-        ? response.data.exploreNewsDtoCollection.map((video: VideoData) => ({
-            id: video.id,
-            title: video.title,
-            category: video.category,
-            channel: video.channel,
-            thumbnail: video.thumbnail,
-            reportDate: video.reportDate,
-            haveGuide: video.haveGuide,
-          }))
-        : [],
-      paging: {
-        lastPage: response.data2.paginationInfo.lastPage,
-        totalCount: response.data2.paginationInfo.totalCount,
-      },
-    };
-  };
-
-  return { postSearchConditionWithToken, postSearchConditionWithoutToken };
+  return { postSearchCondition };
 }

--- a/src/services/remote/like.ts
+++ b/src/services/remote/like.ts
@@ -1,9 +1,9 @@
 import { LikeService } from './../api/like';
-import { privateAPI } from './base';
+import { API } from './base';
 
 export function likeDataRemote(): LikeService {
   const postLikeData = async (newsId: number) => {
-    const response = await privateAPI.post({ url: `/user/favorite/${newsId}` });
+    const response = await API.post({ url: `/user/favorite/${newsId}` });
     if (response.statusCode === 200) {
       return {
         id: response.data.newsId,

--- a/src/services/remote/review.ts
+++ b/src/services/remote/review.ts
@@ -1,10 +1,10 @@
 import { ReviewService } from '../api/review';
 import { PostReviewRequestBody, VideoData } from '../api/types/review';
-import { privateAPI } from './base';
+import { API } from './base';
 
 export function reviewDataRemote(): ReviewService {
   const postFavoriteVideoList = async (body: PostReviewRequestBody) => {
-    const response = await privateAPI.post({ url: `/news/favorite`, data: body });
+    const response = await API.post({ url: `/news/favorite`, data: body });
     if (response.statusCode === 200) {
       return {
         favoriteList: response.data
@@ -28,7 +28,7 @@ export function reviewDataRemote(): ReviewService {
   };
 
   const postHistoryVideoList = async (body: PostReviewRequestBody) => {
-    const response = await privateAPI.post({ url: `/news/history`, data: body });
+    const response = await API.post({ url: `/news/history`, data: body });
     if (response.statusCode === 200) {
       return {
         historyList: response.data


### PR DESCRIPTION
## 🚩 관련 이슈
- close #180 

## 📋 작업 내용
- [x] base.ts에 있는 privateAPI, publicAPI를 API 하나로 통일
- [x] 불필요한 분기 처리 제거
- [x] 스크립트 타이틀 여러 개 있는 뉴스에서 1개짜리 뉴스로 이동 시 생기는 오류 해결

## 📌 PR Point
- base.ts의 `getBaseHeaders` 함수 안에서 로그인 여부에 따라 Authorization 부분을 다르게 처리하고 있습니다.
  따라서 privateAPI, publicAPI 구분 없이 하나로 통신할 수 있었습니다.
- 중복되는 코드를 최대한 없애보려고 노력했습니다.