### PR TITLE
[learn_detail] 메모 컨펌 모달 기능 리팩토링

### DIFF
--- a/src/components/learnDetail/ConfirmModal.tsx
+++ b/src/components/learnDetail/ConfirmModal.tsx
@@ -10,6 +10,8 @@ import {
   INITIAL_MEMO_STATE,
 } from '@src/utils/constant';
 
+export type MemoConfirmModalKey = 'new' | 'edit' | 'delete';
+
 export interface ConfirmModalText {
   mainText: string;
   subText?: string;

--- a/src/components/learnDetail/memo/MemoDotButton.tsx
+++ b/src/components/learnDetail/memo/MemoDotButton.tsx
@@ -3,19 +3,17 @@ import { icDotDefault, icDotHover } from 'public/assets/icons';
 import { useState, useRef, useEffect, Dispatch, SetStateAction } from 'react';
 import styled from 'styled-components';
 import MemoDropdown from './MemoDropdown';
-import { ConfirmModalText } from '../ConfirmModal';
 import { MemoState } from '@src/pages/learn/[id]';
 import { MemoData } from '@src/services/api/types/learn-detail';
 
 interface MemoDotButtonProps {
   memoData: MemoData;
   setMemoState: Dispatch<SetStateAction<MemoState>>;
-  setIsConfirmOpen: (open: boolean) => void;
-  setConfirmModalText: (text: ConfirmModalText) => void;
+  onMemoModal: (type: string) => void;
 }
 
 function MemoDotButton(props: MemoDotButtonProps) {
-  const { memoData, setMemoState, setIsConfirmOpen, setConfirmModalText } = props;
+  const { memoData, setMemoState, onMemoModal } = props;
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const memoDropdownRef = useRef<HTMLDivElement>(null);
 
@@ -42,14 +40,7 @@ function MemoDotButton(props: MemoDotButtonProps) {
         <ImageDiv className="dot" src={icDotHover} alt="추가 작업" layout="fill" />
         <ImageDiv className="dot default" src={icDotDefault} alt="추가 작업" layout="fill" />
       </StMemoDotImage>
-      {isDropdownOpen && (
-        <MemoDropdown
-          memoData={memoData}
-          setMemoState={setMemoState}
-          setIsConfirmOpen={setIsConfirmOpen}
-          setConfirmModalText={setConfirmModalText}
-        />
-      )}
+      {isDropdownOpen && <MemoDropdown memoData={memoData} setMemoState={setMemoState} onMemoModal={onMemoModal} />}
     </StMemoDotButton>
   );
 }

--- a/src/components/learnDetail/memo/MemoDotButton.tsx
+++ b/src/components/learnDetail/memo/MemoDotButton.tsx
@@ -5,11 +5,12 @@ import styled from 'styled-components';
 import MemoDropdown from './MemoDropdown';
 import { MemoState } from '@src/pages/learn/[id]';
 import { MemoData } from '@src/services/api/types/learn-detail';
+import { MemoConfirmModalKey } from '@src/components/learnDetail/ConfirmModal';
 
 interface MemoDotButtonProps {
   memoData: MemoData;
   setMemoState: Dispatch<SetStateAction<MemoState>>;
-  onMemoModal: (type: string) => void;
+  onMemoModal: (type: MemoConfirmModalKey) => void;
 }
 
 function MemoDotButton(props: MemoDotButtonProps) {

--- a/src/components/learnDetail/memo/MemoDropdown.tsx
+++ b/src/components/learnDetail/memo/MemoDropdown.tsx
@@ -1,27 +1,24 @@
 import { COLOR } from '@src/styles/color';
 import { FONT_STYLES } from '@src/styles/fontStyle';
 import styled from 'styled-components';
-import { DELETE_MEMO_CONFIRM_MODAL_TEXT } from '@src/utils/constant';
-import { ConfirmModalText } from '../ConfirmModal';
 import { Dispatch, SetStateAction } from 'react';
 import { MemoState } from '@src/pages/learn/[id]';
 import { MemoData } from '@src/services/api/types/learn-detail';
+import { MEMO_CONFIRM_MODAL_TYPE } from '@src/utils/constant';
 
 interface MemoDropdownProps {
   memoData: MemoData;
   setMemoState: Dispatch<SetStateAction<MemoState>>;
-  setIsConfirmOpen: (open: boolean) => void;
-  setConfirmModalText: (text: ConfirmModalText) => void;
+  onMemoModal: (type: string) => void;
 }
 
 function MemoDropdown(props: MemoDropdownProps) {
-  const { memoData, setMemoState, setIsConfirmOpen, setConfirmModalText } = props;
+  const { memoData, setMemoState, onMemoModal } = props;
   const { id } = memoData;
 
   const handleClickDelete = () => {
     id && setMemoState((prev: MemoState) => ({ ...prev, deleteMemoId: id }));
-    setIsConfirmOpen(true);
-    setConfirmModalText(DELETE_MEMO_CONFIRM_MODAL_TEXT);
+    onMemoModal(MEMO_CONFIRM_MODAL_TYPE.DELETE);
   };
 
   return (

--- a/src/components/learnDetail/memo/MemoDropdown.tsx
+++ b/src/components/learnDetail/memo/MemoDropdown.tsx
@@ -4,12 +4,12 @@ import styled from 'styled-components';
 import { Dispatch, SetStateAction } from 'react';
 import { MemoState } from '@src/pages/learn/[id]';
 import { MemoData } from '@src/services/api/types/learn-detail';
-import { MEMO_CONFIRM_MODAL_TYPE } from '@src/utils/constant';
+import { MemoConfirmModalKey } from '@src/components/learnDetail/ConfirmModal';
 
 interface MemoDropdownProps {
   memoData: MemoData;
   setMemoState: Dispatch<SetStateAction<MemoState>>;
-  onMemoModal: (type: string) => void;
+  onMemoModal: (type: MemoConfirmModalKey) => void;
 }
 
 function MemoDropdown(props: MemoDropdownProps) {
@@ -18,7 +18,7 @@ function MemoDropdown(props: MemoDropdownProps) {
 
   const handleClickDelete = () => {
     id && setMemoState((prev: MemoState) => ({ ...prev, deleteMemoId: id }));
-    onMemoModal(MEMO_CONFIRM_MODAL_TYPE.DELETE);
+    onMemoModal('delete');
   };
 
   return (

--- a/src/components/learnDetail/memo/MemoForm.tsx
+++ b/src/components/learnDetail/memo/MemoForm.tsx
@@ -4,17 +4,15 @@ import { MemoData } from '@src/services/api/types/learn-detail';
 import { COLOR } from '@src/styles/color';
 import { FONT_STYLES } from '@src/styles/fontStyle';
 import {
-  EDIT_MEMO_CONFIRM_MODAL_TEXT,
   INITIAL_MEMO_STATE,
   INITIAL_NUMBER,
   MEMO_CONTENT_MAX_LENGTH,
-  NEW_MEMO_CONFIRM_MODAL_TEXT,
+  MEMO_CONFIRM_MODAL_TYPE,
 } from '@src/utils/constant';
 import { icCheckButton, icMemoXButton, icInactiveCheckButton } from 'public/assets/icons';
 import React, { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import ImageDiv from '../../common/ImageDiv';
-import { ConfirmModalText } from '../ConfirmModal';
 
 interface MemoFormProps {
   scriptId: number;
@@ -22,12 +20,11 @@ interface MemoFormProps {
   memoState: MemoState;
   setMemoList: (memoList: MemoData[]) => void;
   setMemoState: Dispatch<SetStateAction<MemoState>>;
-  setIsConfirmOpen: (open: boolean) => void;
-  setConfirmModalText: (text: ConfirmModalText) => void;
+  onMemoModal: (type: string) => void;
 }
 
 function MemoForm(props: MemoFormProps) {
-  const { scriptId, memoData, memoState, setMemoList, setMemoState, setIsConfirmOpen, setConfirmModalText } = props;
+  const { scriptId, memoData, memoState, setMemoList, setMemoState, onMemoModal } = props;
   const { id, keyword, content, order, startIndex, highlightId } = memoData;
   const { newMemoId, editMemoId } = memoState;
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -54,9 +51,8 @@ function MemoForm(props: MemoFormProps) {
   };
 
   const handleModalOpen = () => {
-    newMemoId !== INITIAL_NUMBER && setConfirmModalText(NEW_MEMO_CONFIRM_MODAL_TEXT);
-    editMemoId !== INITIAL_NUMBER && setConfirmModalText(EDIT_MEMO_CONFIRM_MODAL_TEXT);
-    setIsConfirmOpen(true);
+    newMemoId !== INITIAL_NUMBER && onMemoModal(MEMO_CONFIRM_MODAL_TYPE.NEW);
+    editMemoId !== INITIAL_NUMBER && onMemoModal(MEMO_CONFIRM_MODAL_TYPE.EDIT);
   };
 
   const createMemo = async (newContent: string) => {

--- a/src/components/learnDetail/memo/MemoForm.tsx
+++ b/src/components/learnDetail/memo/MemoForm.tsx
@@ -1,14 +1,10 @@
+import { MemoConfirmModalKey } from '@src/components/learnDetail/ConfirmModal';
 import { MemoState } from '@src/pages/learn/[id]';
 import { api } from '@src/services/api';
 import { MemoData } from '@src/services/api/types/learn-detail';
 import { COLOR } from '@src/styles/color';
 import { FONT_STYLES } from '@src/styles/fontStyle';
-import {
-  INITIAL_MEMO_STATE,
-  INITIAL_NUMBER,
-  MEMO_CONTENT_MAX_LENGTH,
-  MEMO_CONFIRM_MODAL_TYPE,
-} from '@src/utils/constant';
+import { INITIAL_MEMO_STATE, INITIAL_NUMBER, MEMO_CONTENT_MAX_LENGTH } from '@src/utils/constant';
 import { icCheckButton, icMemoXButton, icInactiveCheckButton } from 'public/assets/icons';
 import React, { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
@@ -20,7 +16,7 @@ interface MemoFormProps {
   memoState: MemoState;
   setMemoList: (memoList: MemoData[]) => void;
   setMemoState: Dispatch<SetStateAction<MemoState>>;
-  onMemoModal: (type: string) => void;
+  onMemoModal: (type: MemoConfirmModalKey) => void;
 }
 
 function MemoForm(props: MemoFormProps) {
@@ -51,8 +47,8 @@ function MemoForm(props: MemoFormProps) {
   };
 
   const handleModalOpen = () => {
-    newMemoId !== INITIAL_NUMBER && onMemoModal(MEMO_CONFIRM_MODAL_TYPE.NEW);
-    editMemoId !== INITIAL_NUMBER && onMemoModal(MEMO_CONFIRM_MODAL_TYPE.EDIT);
+    newMemoId !== INITIAL_NUMBER && onMemoModal('new');
+    editMemoId !== INITIAL_NUMBER && onMemoModal('edit');
   };
 
   const createMemo = async (newContent: string) => {

--- a/src/components/learnDetail/memo/MemoItem.tsx
+++ b/src/components/learnDetail/memo/MemoItem.tsx
@@ -11,6 +11,7 @@ import { icArrowUp } from 'public/assets/icons';
 import { MemoData } from '@src/services/api/types/learn-detail';
 import { useRecoilValue } from 'recoil';
 import { isGuideAtom } from '@src/stores/newsState';
+import { MemoConfirmModalKey } from '@src/components/learnDetail/ConfirmModal';
 
 interface MemoProps {
   scriptId: number;
@@ -18,7 +19,7 @@ interface MemoProps {
   memoState: MemoState;
   setMemoList: (memoList: MemoData[]) => void;
   setMemoState: Dispatch<SetStateAction<MemoState>>;
-  onMemoModal: (type: string) => void;
+  onMemoModal: (type: MemoConfirmModalKey) => void;
 }
 
 function MemoItem(props: MemoProps) {

--- a/src/components/learnDetail/memo/MemoItem.tsx
+++ b/src/components/learnDetail/memo/MemoItem.tsx
@@ -49,7 +49,7 @@ function MemoItem(props: MemoProps) {
   };
 
   return (
-    <StMemo className="memo" fold={foldButton}>
+    <StMemoItem className="memo" fold={foldButton}>
       <StKeyword>{keyword}</StKeyword>
       {!content || memoState.editMemoId === id ? (
         <MemoForm
@@ -66,13 +66,13 @@ function MemoItem(props: MemoProps) {
           {!isGuide && <MemoDotButton memoData={memoData} setMemoState={setMemoState} onMemoModal={onMemoModal} />}
         </>
       )}
-    </StMemo>
+    </StMemoItem>
   );
 }
 
 export default MemoItem;
 
-const StMemo = styled.div<{ fold: boolean }>`
+const StMemoItem = styled.div<{ fold: boolean }>`
   position: relative;
 
   margin-right: 0.8rem;

--- a/src/components/learnDetail/memo/MemoItem.tsx
+++ b/src/components/learnDetail/memo/MemoItem.tsx
@@ -4,7 +4,6 @@ import { FONT_STYLES } from '@src/styles/fontStyle';
 import { Dispatch, SetStateAction, useState } from 'react';
 import MemoForm from './MemoForm';
 import MemoDotButton from './MemoDotButton';
-import { ConfirmModalText } from '../ConfirmModal';
 import { MEMO_CONTENT_MAX } from '@src/utils/constant';
 import { MemoState } from '@src/pages/learn/[id]';
 import ImageDiv from '@src/components/common/ImageDiv';
@@ -19,13 +18,12 @@ interface MemoProps {
   memoState: MemoState;
   setMemoList: (memoList: MemoData[]) => void;
   setMemoState: Dispatch<SetStateAction<MemoState>>;
-  setIsConfirmOpen: (open: boolean) => void;
-  setConfirmModalText: (text: ConfirmModalText) => void;
+  onMemoModal: (type: string) => void;
 }
 
 function MemoItem(props: MemoProps) {
   const isGuide = useRecoilValue(isGuideAtom);
-  const { scriptId, memoData, memoState, setMemoList, setMemoState, setIsConfirmOpen, setConfirmModalText } = props;
+  const { scriptId, memoData, memoState, setMemoList, setMemoState, onMemoModal } = props;
   const { id, keyword, content } = memoData;
   const [foldButton, setFoldButton] = useState(false);
 
@@ -60,20 +58,12 @@ function MemoItem(props: MemoProps) {
           memoState={memoState}
           setMemoList={setMemoList}
           setMemoState={setMemoState}
-          setIsConfirmOpen={setIsConfirmOpen}
-          setConfirmModalText={setConfirmModalText}
+          onMemoModal={onMemoModal}
         />
       ) : (
         <>
           <StContent>{showContent()}</StContent>
-          {!isGuide && (
-            <MemoDotButton
-              memoData={memoData}
-              setMemoState={setMemoState}
-              setIsConfirmOpen={setIsConfirmOpen}
-              setConfirmModalText={setConfirmModalText}
-            />
-          )}
+          {!isGuide && <MemoDotButton memoData={memoData} setMemoState={setMemoState} onMemoModal={onMemoModal} />}
         </>
       )}
     </StMemo>

--- a/src/components/learnDetail/memo/MemoItem.tsx
+++ b/src/components/learnDetail/memo/MemoItem.tsx
@@ -23,7 +23,7 @@ interface MemoProps {
   setConfirmModalText: (text: ConfirmModalText) => void;
 }
 
-function Memo(props: MemoProps) {
+function MemoItem(props: MemoProps) {
   const isGuide = useRecoilValue(isGuideAtom);
   const { scriptId, memoData, memoState, setMemoList, setMemoState, setIsConfirmOpen, setConfirmModalText } = props;
   const { id, keyword, content } = memoData;
@@ -80,7 +80,7 @@ function Memo(props: MemoProps) {
   );
 }
 
-export default Memo;
+export default MemoItem;
 
 const StMemo = styled.div<{ fold: boolean }>`
   position: relative;

--- a/src/components/learnDetail/memo/MemoList.tsx
+++ b/src/components/learnDetail/memo/MemoList.tsx
@@ -1,7 +1,7 @@
 import { MemoData } from '@src/services/api/types/learn-detail';
 import { COLOR } from '@src/styles/color';
 import styled from 'styled-components';
-import Memo from './Memo';
+import MemoItem from './MemoItem';
 import { ConfirmModalText } from '../ConfirmModal';
 import { MemoInfo, MemoState } from '@src/pages/learn/[id]';
 import { Dispatch, SetStateAction, useEffect } from 'react';
@@ -59,7 +59,7 @@ function MemoList(props: MemoListProps) {
         };
 
         return (
-          <Memo
+          <MemoItem
             key={memo.id}
             scriptId={memoInfo.scriptId}
             memoData={tempMemo}

--- a/src/components/learnDetail/memo/MemoList.tsx
+++ b/src/components/learnDetail/memo/MemoList.tsx
@@ -5,6 +5,7 @@ import MemoItem from './MemoItem';
 import { MemoInfo, MemoState } from '@src/pages/learn/[id]';
 import { Dispatch, SetStateAction, useEffect } from 'react';
 import { INITIAL_NUMBER } from '@src/utils/constant';
+import { MemoConfirmModalKey } from '@src/components/learnDetail/ConfirmModal';
 
 interface MemoListProps {
   memoList: MemoData[];
@@ -12,7 +13,7 @@ interface MemoListProps {
   memoInfo: MemoInfo;
   setMemoList: Dispatch<SetStateAction<MemoData[]>>;
   setMemoState: Dispatch<SetStateAction<MemoState>>;
-  onMemoModal: (type: string) => void;
+  onMemoModal: (type: MemoConfirmModalKey) => void;
 }
 
 function MemoList(props: MemoListProps) {

--- a/src/components/learnDetail/memo/MemoList.tsx
+++ b/src/components/learnDetail/memo/MemoList.tsx
@@ -2,7 +2,6 @@ import { MemoData } from '@src/services/api/types/learn-detail';
 import { COLOR } from '@src/styles/color';
 import styled from 'styled-components';
 import MemoItem from './MemoItem';
-import { ConfirmModalText } from '../ConfirmModal';
 import { MemoInfo, MemoState } from '@src/pages/learn/[id]';
 import { Dispatch, SetStateAction, useEffect } from 'react';
 import { INITIAL_NUMBER } from '@src/utils/constant';
@@ -13,12 +12,11 @@ interface MemoListProps {
   memoInfo: MemoInfo;
   setMemoList: Dispatch<SetStateAction<MemoData[]>>;
   setMemoState: Dispatch<SetStateAction<MemoState>>;
-  setIsConfirmOpen: (open: boolean) => void;
-  setConfirmModalText: (text: ConfirmModalText) => void;
+  onMemoModal: (type: string) => void;
 }
 
 function MemoList(props: MemoListProps) {
-  const { memoList, memoState, memoInfo, setMemoList, setMemoState, setIsConfirmOpen, setConfirmModalText } = props;
+  const { memoList, memoState, memoInfo, setMemoList, setMemoState, onMemoModal } = props;
 
   useEffect(() => {
     setMemoList((prev: MemoData[]) => prev.filter((memo) => memo.content !== ''));
@@ -66,8 +64,7 @@ function MemoList(props: MemoListProps) {
             memoState={memoState}
             setMemoList={setMemoList}
             setMemoState={setMemoState}
-            setIsConfirmOpen={setIsConfirmOpen}
-            setConfirmModalText={setConfirmModalText}
+            onMemoModal={onMemoModal}
           />
         );
       })}

--- a/src/components/learnDetail/record/EmptyRecord.tsx
+++ b/src/components/learnDetail/record/EmptyRecord.tsx
@@ -2,7 +2,7 @@ import { COLOR } from '@src/styles/color';
 import { FONT_STYLES } from '@src/styles/fontStyle';
 import { icRecordEmpty } from 'public/assets/icons';
 import styled from 'styled-components';
-import ImageDiv from '../../common/ImageDiv';
+import ImageDiv from '@src/components/common/ImageDiv';
 
 function EmptyRecord() {
   return (

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -747,17 +747,15 @@ function LearnDetail() {
                   {studyLogTab === 'memo' ? (
                     <StMemoWrapper>
                       {memoList.length || memoState.newMemoId !== INITIAL_NUMBER ? (
-                        <>
-                          <MemoList
-                            memoList={memoList}
-                            memoState={memoState}
-                            memoInfo={memoInfo}
-                            setMemoList={setMemoList}
-                            setMemoState={setMemoState}
-                            setIsConfirmOpen={setIsConfirmOpen}
-                            setConfirmModalText={setConfirmModalText}
-                          />
-                        </>
+                        <MemoList
+                          memoList={memoList}
+                          memoState={memoState}
+                          memoInfo={memoInfo}
+                          setMemoList={setMemoList}
+                          setMemoState={setMemoState}
+                          setIsConfirmOpen={setIsConfirmOpen}
+                          setConfirmModalText={setConfirmModalText}
+                        />
                       ) : (
                         <EmptyMemo />
                       )}

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -10,7 +10,7 @@ import ImageDiv from '@src/components/common/ImageDiv';
 import Like from '@src/components/common/Like';
 import SEO from '@src/components/common/SEO';
 import NewsList from '@src/components/common/NewsList';
-import ConfirmModal, { ConfirmModalText } from '@src/components/learnDetail/ConfirmModal';
+import ConfirmModal, { ConfirmModalText, MemoConfirmModalKey } from '@src/components/learnDetail/ConfirmModal';
 import ContextMenu from '@src/components/learnDetail/ContextMenu';
 import GuideModal from '@src/components/learnDetail/GuideModal';
 import EmptyMemo from '@src/components/learnDetail/memo/EmptyMemo';
@@ -40,9 +40,7 @@ import {
   VIDEO_STATE_CUED,
   VIDEO_STATE_PAUSED,
   NEW_MEMO_CONFIRM_MODAL_TEXT,
-  EDIT_MEMO_CONFIRM_MODAL_TEXT,
-  DELETE_MEMO_CONFIRM_MODAL_TEXT,
-  MEMO_CONFIRM_MODAL_TYPE,
+  MemoConfirmModalTextByType,
 } from '@src/utils/constant';
 import { useBodyScrollLock } from '@src/hooks/useBodyScrollLock';
 import {
@@ -357,19 +355,9 @@ function LearnDetail() {
     }
   };
 
-  const handleMemoModal = (type: string) => {
+  const handleMemoModal = (type: MemoConfirmModalKey) => {
     setIsConfirmOpen(true);
-    switch (type) {
-      case MEMO_CONFIRM_MODAL_TYPE.NEW:
-        setConfirmModalText(NEW_MEMO_CONFIRM_MODAL_TEXT);
-        break;
-      case MEMO_CONFIRM_MODAL_TYPE.EDIT:
-        setConfirmModalText(EDIT_MEMO_CONFIRM_MODAL_TEXT);
-        break;
-      case MEMO_CONFIRM_MODAL_TYPE.DELETE:
-        setConfirmModalText(DELETE_MEMO_CONFIRM_MODAL_TEXT);
-        break;
-    }
+    setConfirmModalText(MemoConfirmModalTextByType[type]);
   };
 
   const handleTitleDeleteModal = () => {

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -29,7 +29,6 @@ import { isGuideAtom } from '@src/stores/newsState';
 import { COLOR } from '@src/styles/color';
 import { FONT_STYLES } from '@src/styles/fontStyle';
 import {
-  NEW_MEMO_CONFIRM_MODAL_TEXT,
   INITIAL_NUMBER,
   INITIAL_MEMO_STATE,
   INITIAL_MEMO,
@@ -40,6 +39,10 @@ import {
   ABSOLUTE_RIGHT_LIMIT,
   VIDEO_STATE_CUED,
   VIDEO_STATE_PAUSED,
+  NEW_MEMO_CONFIRM_MODAL_TEXT,
+  EDIT_MEMO_CONFIRM_MODAL_TEXT,
+  DELETE_MEMO_CONFIRM_MODAL_TEXT,
+  MEMO_CONFIRM_MODAL_TYPE,
 } from '@src/utils/constant';
 import { useBodyScrollLock } from '@src/hooks/useBodyScrollLock';
 import {
@@ -351,6 +354,21 @@ function LearnDetail() {
         setTitleList(names);
       }
       return;
+    }
+  };
+
+  const handleMemoModal = (type: string) => {
+    setIsConfirmOpen(true);
+    switch (type) {
+      case MEMO_CONFIRM_MODAL_TYPE.NEW:
+        setConfirmModalText(NEW_MEMO_CONFIRM_MODAL_TEXT);
+        break;
+      case MEMO_CONFIRM_MODAL_TYPE.EDIT:
+        setConfirmModalText(EDIT_MEMO_CONFIRM_MODAL_TEXT);
+        break;
+      case MEMO_CONFIRM_MODAL_TYPE.DELETE:
+        setConfirmModalText(DELETE_MEMO_CONFIRM_MODAL_TEXT);
+        break;
     }
   };
 
@@ -753,8 +771,7 @@ function LearnDetail() {
                           memoInfo={memoInfo}
                           setMemoList={setMemoList}
                           setMemoState={setMemoState}
-                          setIsConfirmOpen={setIsConfirmOpen}
-                          setConfirmModalText={setConfirmModalText}
+                          onMemoModal={handleMemoModal}
                         />
                       ) : (
                         <EmptyMemo />

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -1,8 +1,4 @@
-export const MEMO_CONFIRM_MODAL_TYPE = {
-  NEW: 'new',
-  EDIT: 'edit',
-  DELETE: 'delete',
-};
+import { ConfirmModalText, MemoConfirmModalKey } from '@src/components/learnDetail/ConfirmModal';
 
 export const NEW_MEMO_CONFIRM_MODAL_TEXT = {
   mainText: '메모 작성을 취소하시겠습니까?',
@@ -22,6 +18,12 @@ export const DELETE_MEMO_CONFIRM_MODAL_TEXT = {
   mainText: '메모를 삭제하시겠습니까?',
   leftButtonText: '취소',
   rightButtonText: '삭제하기',
+};
+
+export const MemoConfirmModalTextByType: Record<MemoConfirmModalKey, ConfirmModalText> = {
+  new: NEW_MEMO_CONFIRM_MODAL_TEXT,
+  edit: EDIT_MEMO_CONFIRM_MODAL_TEXT,
+  delete: DELETE_MEMO_CONFIRM_MODAL_TEXT,
 };
 
 export const DELETE_SCRIPT_CONFIRM_MODAL_TEXT = {

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -1,3 +1,9 @@
+export const MEMO_CONFIRM_MODAL_TYPE = {
+  NEW: 'new',
+  EDIT: 'edit',
+  DELETE: 'delete',
+};
+
 export const NEW_MEMO_CONFIRM_MODAL_TEXT = {
   mainText: '메모 작성을 취소하시겠습니까?',
   subText: '작성 취소 선택시, 작성된 메모는 저장되지 않습니다.',


### PR DESCRIPTION
## 🚩 관련 이슈
- close #187 

## 📋 작업 내용
- [x] 메모 컨펌 모달 기능 함수화
- [x] 메모 관련 컴포넌트로 함수 내려주기

## 📌 PR Point
- 기존에 `setIsConfirmOpen`과 `setConfirmModalText`을 `MemoDropdown`과 `MemoForm`까지 각각 내려주었는데
이를 아래와 같이 함수로 변경하여 한번에 내려주도록 코드를 수정하였습니다. 
```c
  const handleMemoModal = (type: string) => {
    setIsConfirmOpen(true);
    switch (type) {
      case MEMO_CONFIRM_MODAL_TYPE.NEW:
        setConfirmModalText(NEW_MEMO_CONFIRM_MODAL_TEXT);
        break;
      case MEMO_CONFIRM_MODAL_TYPE.EDIT:
        setConfirmModalText(EDIT_MEMO_CONFIRM_MODAL_TEXT);
        break;
      case MEMO_CONFIRM_MODAL_TYPE.DELETE:
        setConfirmModalText(DELETE_MEMO_CONFIRM_MODAL_TEXT);
        break;
    }
  };
```