### PR TITLE
[common] 유튜브 썸네일 이미지 최적화

### DIFF
--- a/src/components/common/NewsList.tsx
+++ b/src/components/common/NewsList.tsx
@@ -20,16 +20,18 @@ interface NewsListProps {
 }
 
 function NewsList(props: NewsListProps) {
-  const setIsGuide = useSetRecoilState(isGuideAtom);
   const { type, newsList, onClickLike } = props;
   const router = useRouter();
+  const [isWebpError, setIsWebpError] = useState(false);
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+  const setIsGuide = useSetRecoilState(isGuideAtom);
   const { lockScroll, unlockScroll } = useBodyScrollLock();
   const login = useRecoilValue(loginState);
 
   return (
     <StNewsList type={type}>
       {newsList.map(({ id, title, category, channel, thumbnail, reportDate, isFavorite, haveGuide }) => {
+        const webpThumbnail = thumbnail.replace('/vi/', '/vi_webp/').replace('.jpg', '.webp');
         return (
           <StNewsWrapper
             key={id}
@@ -47,9 +49,8 @@ function NewsList(props: NewsListProps) {
             <StThumbnail type={type}>
               <ImageDiv
                 className="thumbnail"
-                src={thumbnail}
-                blurDataURL={thumbnail}
-                placeholder="blur"
+                src={isWebpError ? thumbnail : webpThumbnail}
+                onError={() => setIsWebpError(true)}
                 layout="fill"
                 alt=""
               />

--- a/src/components/common/NewsList.tsx
+++ b/src/components/common/NewsList.tsx
@@ -144,6 +144,7 @@ const StNewsWrapper = styled.article<{ type: string }>`
 const StThumbnail = styled.div<{ type: string }>`
   position: relative;
   cursor: pointer;
+  border-radius: 1rem;
 
   ${({ type }) =>
     type === 'guide' &&

--- a/src/components/common/NewsList.tsx
+++ b/src/components/common/NewsList.tsx
@@ -143,7 +143,6 @@ const StNewsWrapper = styled.article<{ type: string }>`
 
 const StThumbnail = styled.div<{ type: string }>`
   position: relative;
-  border-radius: 1rem;
   cursor: pointer;
 
   ${({ type }) =>
@@ -179,8 +178,10 @@ const StThumbnail = styled.div<{ type: string }>`
     position: relative;
     z-index: -1;
     padding-top: 56%;
+    background-color: ${COLOR.GRAY_5};
+    border-radius: 1rem;
 
-    & img {
+    img {
       border-radius: 1rem;
       object-fit: cover;
     }

--- a/src/components/landing/MobileContainer.tsx
+++ b/src/components/landing/MobileContainer.tsx
@@ -140,7 +140,7 @@ const StMobileContainer = styled.div`
 
 const StFirstSlide = styled.div`
   text-align: center;
-  height: 65rem;
+  height: 69.4rem;
   background: url(${imgMobileBgFirst.src}) center/cover no-repeat;
 
   p:first-child {


### PR DESCRIPTION
## 🚩 관련 이슈
- close #197 

## 📋 작업 내용
- [x] 서버에서 보내주는 jpg 이미지를 webp로 바꿔서 적용
- [x] webp 유튜브 썸네일이 없는 경우만 원래대로 jpg로 처리
- [x] blurDataURL 대신 background-color 적용

## 📌 PR Point
- 서비스 특성상 한 페이지에서 보여줘야 하는 썸네일 이미지가 많습니다. 근데 서버에서 전부 **대용량 jpg**로 전달하고 있다는 점이 성능에 영향을 줄 수 있다고 생각했습니다. 찾아보니 유튜브에서는 jpg 말고 **webp** 포맷으로도 썸네일을 제공하고 있었습니다. 그래서 webp 포맷을 사용할 수 있도록 수정했습니다.

- 유튜브에서 특정 썸네일은 webp 포맷을 제공하지 않습니다. 따라서 이런 경우에만 jpg 썸네일을 보여주도록 처리했습니다.

- 그동안 블러 처리된 이미지를 placeholder로 제공하는 것이 항상 좋은 줄 알았습니다. 하지만 [공식 문서](https://nextjs.org/docs/api-reference/next/image#blurdataurl)를 읽어보니 다음과 같은 내용이 있었습니다.
  >It will be enlarged and blurred, so a very small image (10px or less) is recommended. Including larger images as placeholders may harm your application performance.
  
  그리고 네트워크 탭을 통해 상황별로 비교하면서 다음과 같은 정보를 확인할 수 있었습니다.
  |blurDataURL을 jpg로 제공할 때|blurDataURL을 webp로 제공할 때|blurDataURL을 제공하지 않을 때|
  |:-:|:-:|:-:|
  |<img src="https://user-images.githubusercontent.com/58380158/218685741-360578d9-ba13-44bf-b8d2-4b69f2f2059a.png" width="400" />|<img src="https://user-images.githubusercontent.com/58380158/218687787-b42a7107-fb71-41b3-89aa-d517eb1a7564.png" width="400" />|<img src="https://user-images.githubusercontent.com/58380158/218686107-227e050e-9062-4d7a-ace7-65d7616cf571.png" width="400" />|
  |이미지 사이즈가 커서<br />다운로드 시간이 길다.|이미지 사이즈가 작아서<br />다운로드 시간이 짧다.|아예 주고받을 게 없다.|

  그래서 블러 처리된 이미지 대신 회색 배경을 보여주는 방식으로 수정했습니다.

## 📸 스크린샷
|Before|After|
|:-:|:-:|
|<img src="https://user-images.githubusercontent.com/58380158/218684518-f02678fc-3b0b-4cf5-8165-94b6ea61acb7.png" width="350">|<img src="https://user-images.githubusercontent.com/58380158/218684028-7274fdcd-9c0a-4ad4-b7b6-3b3ca966eb59.png" width="350">|