### PR TITLE
[learn_detail] 메모 관련 버그 수정

### DIFF
--- a/src/components/learnDetail/memo/MemoForm.tsx
+++ b/src/components/learnDetail/memo/MemoForm.tsx
@@ -114,11 +114,9 @@ function MemoForm(props: MemoFormProps) {
     const { newMemoId, editMemoId } = memoState;
     if (newMemoId !== INITIAL_NUMBER || editMemoId !== INITIAL_NUMBER) {
       window.addEventListener('mousedown', handleClickOutside);
-      window.addEventListener('contextmenu', handleClickOutside);
     }
     return () => {
       window.removeEventListener('mousedown', handleClickOutside);
-      window.removeEventListener('contextmenu', handleClickOutside);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [memoState]);

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -78,7 +78,6 @@ function LearnDetail() {
   const [prevLink, setPrevLink] = useState('');
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [isGuideOver, setIsGuideOver] = useState<boolean>(false);
-  const [highlightIndex, setHighlightIndex] = useState<number>(INITIAL_NUMBER);
   const [titleList, setTitleList] = useState<Name[]>([]);
   const [clickedTitleIndex, setClickedTitleIndex] = useState(0);
   const [isTitleInputVisible, setIsTitleInputVisible] = useState(false);
@@ -117,7 +116,6 @@ function LearnDetail() {
       for (let i = 0; i < childNodes.length; i++) {
         const childElement = childNodes[i] as HTMLElement;
         if (childElement.id === targetId) {
-          setHighlightIndex(stringLength);
           return stringLength;
         }
         if (childNodes[i].textContent !== '/') {
@@ -269,16 +267,22 @@ function LearnDetail() {
     }
 
     const markTag = contextTarget.closest('mark');
-    const startIndex = markTag && getHighlightIndex(contextTarget?.parentNode, contextTarget.id);
-    if (startIndex && markTag) {
-      setMemoInfo({
-        scriptId,
-        order,
-        startIndex,
-        keyword: markTag.innerText.replaceAll('/', ' '),
-        highlightId: markTag.id,
-      });
-      setClickedMemo(memoList.find((memo) => memo.highlightId === markTag.id));
+    if (markTag) {
+      const startIndex = getHighlightIndex(contextTarget?.parentNode, contextTarget.id);
+      const { newMemoId, editMemoId } = memoState;
+      if (newMemoId === INITIAL_NUMBER && editMemoId === INITIAL_NUMBER) {
+        setIsContextMenuOpen(true);
+        if (startIndex) {
+          setMemoInfo({
+            scriptId,
+            order,
+            startIndex,
+            keyword: markTag.innerText.replaceAll('/', ' '),
+            highlightId: markTag.id,
+          });
+          setClickedMemo(memoList.find((memo) => memo.highlightId === markTag.id));
+        }
+      }
     }
   };
 
@@ -375,21 +379,6 @@ function LearnDetail() {
   }, [clickedDeleteMemo, memoState]);
 
   useEffect(() => {
-    const { newMemoId, editMemoId } = memoState;
-    if (highlightIndex !== INITIAL_NUMBER && newMemoId === INITIAL_NUMBER && editMemoId === INITIAL_NUMBER) {
-      setIsContextMenuOpen(true);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [highlightIndex]);
-
-  useEffect(() => {
-    const { newMemoId, editMemoId } = memoState;
-    if (newMemoId === INITIAL_NUMBER && editMemoId === INITIAL_NUMBER) {
-      setHighlightIndex(INITIAL_NUMBER);
-    }
-  }, [memoState]);
-
-  useEffect(() => {
     if (isHighlight || isSpacing) {
       setIsEditing(true);
     } else {
@@ -447,7 +436,6 @@ function LearnDetail() {
         eventTarget.tagName !== 'SPAN'
       ) {
         setIsContextMenuOpen(false);
-        setHighlightIndex(INITIAL_NUMBER);
       }
     };
     if (isContextMenuOpen) {


### PR DESCRIPTION
## 🚩 관련 이슈
- close #204 

## 📋 작업 내용
- [x] 메모 추가시 아무것도 작성하지 않고 다른 하이라이트 우클릭하면 해당 키워드로 이름이 바뀌는 버그 수정
- [x] 메모 추가시 내용 작성 후 다른곳 우클릭하면 메모가 두개 생성되는 버그 수정

## 📌 PR Point
- `mousedown` 이벤트가 좌클릭 우클릭 상관없이 발생하는 이벤트였습니다. 따라서 메모 폼 바깥을 클릭할 경우 `mousedown`일 경우와 `contextmenu` 클릭일 경우 이벤트 리스너를 달아주고 있었는데 두 이벤트가 모두 호출이 되어 메모가 두 번 생성되고 있었습니다.
- 메모 작성 도중 다른 하이라이트 우클릭시에 대한 처리가 안되어 있었습니다. 해당 부분 처리 완료했습니다.

## 📸 스크린샷
[버그 수정 전]

https://user-images.githubusercontent.com/63948884/225901719-81e51293-5b30-4d9a-b80e-7d6910c62e4d.mp4


[버그 수정 후]

https://user-images.githubusercontent.com/63948884/225901676-cbf38a85-7b15-47b4-a537-698d1db4873a.mov


