### PR TITLE
[learn_detail] 하이라이트, 끊어읽기 삭제 로직 분리

### DIFF
--- a/src/hooks/useDeleteElement.ts
+++ b/src/hooks/useDeleteElement.ts
@@ -90,8 +90,6 @@ function useDeleteElement(props: useDeleteElementProps) {
 
   useEffect(() => {
     (async () => {
-      console.log('order', order);
-      console.log('text', text);
       if (order !== -1 && text !== '' && order && text && videoData?.names) {
         const id = videoData?.names[clickedTitleIndex].id;
         await api.learnDetailService.postSentenceData({ order, text }, id, clickedTitleIndex);

--- a/src/hooks/useDeleteElement.ts
+++ b/src/hooks/useDeleteElement.ts
@@ -6,7 +6,7 @@ import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 interface useDeleteElementProps {
   rightClickedElement?: HTMLElement;
   clickedTitleIndex: number;
-  detailId?: string | string[];
+  detailId: string;
   videoData?: VideoData;
   setVideoData: Dispatch<SetStateAction<VideoData | undefined>>;
   updateMemoList: (type: MemoConfirmModalKey, content?: string) => void;

--- a/src/hooks/useDeleteElement.ts
+++ b/src/hooks/useDeleteElement.ts
@@ -1,14 +1,14 @@
 import { MemoConfirmModalKey } from '@src/components/learnDetail/ConfirmModal';
 import { api } from '@src/services/api';
 import { VideoData } from '@src/services/api/types/learn-detail';
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
 interface useDeleteElementProps {
   rightClickedElement?: HTMLElement;
   clickedTitleIndex: number;
   detailId?: string | string[];
   videoData?: VideoData;
-  setVideoData: React.Dispatch<React.SetStateAction<VideoData | undefined>>;
+  setVideoData: Dispatch<SetStateAction<VideoData | undefined>>;
   updateMemoList: (type: MemoConfirmModalKey, content?: string) => void;
 }
 

--- a/src/hooks/useDeleteElement.ts
+++ b/src/hooks/useDeleteElement.ts
@@ -1,0 +1,110 @@
+import { MemoConfirmModalKey } from '@src/components/learnDetail/ConfirmModal';
+import { api } from '@src/services/api';
+import { VideoData } from '@src/services/api/types/learn-detail';
+import { useEffect, useState } from 'react';
+
+interface useDeleteElementProps {
+  rightClickedElement?: HTMLElement;
+  clickedTitleIndex: number;
+  detailId?: string | string[];
+  videoData?: VideoData;
+  setVideoData: React.Dispatch<React.SetStateAction<VideoData | undefined>>;
+  updateMemoList: (type: MemoConfirmModalKey, content?: string) => void;
+}
+
+function useDeleteElement(props: useDeleteElementProps) {
+  const { rightClickedElement, clickedTitleIndex, detailId, videoData, setVideoData, updateMemoList } = props;
+  const [clickedDeleteType, setClickedDeleteType] = useState<string>('');
+  const [order, setOrder] = useState<number>();
+  const [text, setText] = useState<string>();
+
+  const nodeToText = (anchorNode: Node | null | undefined) => {
+    let textValue = '';
+    if (anchorNode?.nodeName === 'MARK') {
+      nodeToText(anchorNode.parentNode);
+      return;
+    }
+
+    if (anchorNode?.childNodes) {
+      for (let i = 0; i < anchorNode?.childNodes.length; i++) {
+        const childNodeItem = anchorNode?.childNodes[i];
+        const elementId = childNodeItem.firstChild?.parentElement?.id;
+        switch (childNodeItem.nodeName) {
+          case '#text':
+            textValue += childNodeItem.nodeValue;
+            break;
+          case 'MARK':
+            if (childNodeItem.textContent?.includes('/')) {
+              const markInnerHTML = childNodeItem.firstChild?.parentElement?.innerHTML;
+              textValue += `<mark id=${elementId}>${markInnerHTML}</mark>`;
+            } else {
+              textValue += `<mark id=${elementId}>${childNodeItem.textContent}</mark>`;
+            }
+            break;
+          case 'SPAN':
+            textValue += `<span id=${elementId}>/</span>`;
+            break;
+        }
+      }
+      setText(textValue);
+    }
+  };
+
+  const deleteElement = () => {
+    if (rightClickedElement) {
+      const parentElement = rightClickedElement.parentElement;
+      const removeElement = document.getElementById(rightClickedElement.id);
+      const fragment = document.createDocumentFragment();
+      const div = document.createElement('div');
+      const blank = document.createTextNode(' ');
+
+      switch (clickedDeleteType) {
+        case 'MARK':
+          if (removeElement?.innerHTML) {
+            div.innerHTML = removeElement?.innerHTML;
+          }
+          while (div.firstChild) {
+            fragment.appendChild(div.firstChild);
+          }
+          removeElement?.replaceWith(fragment);
+          nodeToText(parentElement);
+          updateMemoList('delete');
+          break;
+        case 'SPAN':
+          if (removeElement) {
+            removeElement.replaceWith(blank);
+          }
+          nodeToText(parentElement);
+          break;
+      }
+    }
+  };
+
+  useEffect(() => {
+    setClickedDeleteType('');
+    if (clickedDeleteType) {
+      deleteElement();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clickedDeleteType]);
+
+  useEffect(() => {
+    (async () => {
+      console.log('order', order);
+      console.log('text', text);
+      if (order !== -1 && text !== '' && order && text && videoData?.names) {
+        const id = videoData?.names[clickedTitleIndex].id;
+        await api.learnDetailService.postSentenceData({ order, text }, id, clickedTitleIndex);
+        const data = await api.learnDetailService.getPrivateVideoData(Number(detailId), clickedTitleIndex);
+        setVideoData(data);
+        setText('');
+        setOrder(-1);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [order, text]);
+
+  return { setOrder, setText, setClickedDeleteType, nodeToText };
+}
+
+export default useDeleteElement;

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -63,7 +63,7 @@ export interface MemoInfo {
 
 function LearnDetail() {
   const router = useRouter();
-  const { id: detailId } = router.query;
+  const detailId = router.query.id as string;
   const [isGuide, setIsGuide] = useRecoilState(isGuideAtom);
   const isLoggedIn = useRecoilValue(loginState);
   const [videoData, setVideoData] = useState<VideoData>();


### PR DESCRIPTION
## 🚩 관련 이슈
- close #211 

## 📋 작업 내용
- [x] [id].tsx 파일에 있는 하이라이트, 끊어읽기 삭제 관련 로직을 커스텀 훅으로 분리

## 📌 PR Point
- 제 코드가 아니어서 로직 쪽은 가능하면 건들지 않으려고 했습니다만 줄일 수 있겠다 싶은 부분은 수정하였습니다. 수정한 부분은 코멘트로 표시해두겠습니다. 
- 기존 `ScriptEdit` 컴포넌트의 대부분의 state가 id 파일에 있는 state와 동일하여 props로 내려주는 식으로 수정하였습니다.
- 여러번 테스트 해봤지만 미처 발견하지 못한 동작 오류가 있을 수도 있습니다. 이상한 점이 있으면 말씀해주세요!