### PR TITLE
[learn_detail] 동영상 재생 렌더링 최적화

### DIFF
--- a/src/constants/learnDetail/index.ts
+++ b/src/constants/learnDetail/index.ts
@@ -1,6 +1,4 @@
 export const VIDEO_STATE_PLAYING = 1;
-export const VIDEO_STATE_PAUSED = 2;
-export const VIDEO_STATE_CUED = 5;
 export const SCRIPT_MAX_COUNT = 3;
 export const SCRIPT_TITLE_MAX_LENGTH = 100;
 export const CONTEXT_MENU_WIDTH = 144;

--- a/src/constants/learnDetail/index.ts
+++ b/src/constants/learnDetail/index.ts
@@ -1,3 +1,4 @@
+export const VIDEO_STATE_PLAYING = 1;
 export const VIDEO_STATE_PAUSED = 2;
 export const VIDEO_STATE_CUED = 5;
 export const SCRIPT_MAX_COUNT = 3;

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -4,12 +4,7 @@ import ContextMenu from '@src/components/learnDetail/ContextMenu';
 import { RecordStatusBar } from '@src/components/learnDetail/record';
 import { ScriptEdit, ScriptEditButtonContainer } from '@src/components/learnDetail/scriptEdit';
 import { LearningButton, SpeechGuideTitle } from '@src/components/learnDetail/speechGuide';
-import {
-  SCRIPT_MAX_COUNT,
-  VIDEO_STATE_CUED,
-  VIDEO_STATE_PAUSED,
-  VIDEO_STATE_PLAYING,
-} from '@src/constants/learnDetail';
+import { SCRIPT_MAX_COUNT, VIDEO_STATE_PLAYING } from '@src/constants/learnDetail';
 import { INITIAL, INITIAL_MEMO_STATE } from '@src/constants/learnDetail/memo';
 import { DELETE_SCRIPT_MODAL_TEXT, MEMO_MODAL_TEXT_TYPE, NEW_MEMO_MODAL_TEXT } from '@src/constants/learnDetail/modal';
 import { useBodyScrollLock, useClickOutside } from '@src/hooks/common';
@@ -160,21 +155,16 @@ function LearnDetail() {
 
   useEffect(() => {
     if (!videoData) return;
-    const { sentences } = videoData;
-    if (currentSentenceIndex >= sentences.length) {
+    if (currentSentenceIndex >= videoData.sentences.length) {
       setCurrentSentenceIndex(0);
       return;
     }
-
-    const delay = (sentences[currentSentenceIndex].endTime - sentences[currentSentenceIndex].startTime) * 1000;
-    const timeoutId = setTimeout(() => {
-      videoState === VIDEO_STATE_PLAYING && setCurrentSentenceIndex((prev) => prev + 1);
-    }, delay);
-
-    if (videoState === VIDEO_STATE_PAUSED || videoState === VIDEO_STATE_CUED) {
-      timeoutId && clearTimeout(timeoutId);
+    if (videoState === VIDEO_STATE_PLAYING) {
+      const currentSentence = videoData.sentences[currentSentenceIndex];
+      const delay = (currentSentence.endTime - currentSentence.startTime) * 1000;
+      const timeoutId = setTimeout(() => setCurrentSentenceIndex((prev) => prev + 1), delay);
+      return () => timeoutId && clearTimeout(timeoutId);
     }
-    return () => timeoutId && clearTimeout(timeoutId);
   }, [currentSentenceIndex, videoData, videoState]);
 
   useClickOutside({

--- a/src/pages/learn/[id].tsx
+++ b/src/pages/learn/[id].tsx
@@ -4,7 +4,12 @@ import ContextMenu from '@src/components/learnDetail/ContextMenu';
 import { RecordStatusBar } from '@src/components/learnDetail/record';
 import { ScriptEdit, ScriptEditButtonContainer } from '@src/components/learnDetail/scriptEdit';
 import { LearningButton, SpeechGuideTitle } from '@src/components/learnDetail/speechGuide';
-import { SCRIPT_MAX_COUNT, VIDEO_STATE_CUED, VIDEO_STATE_PAUSED } from '@src/constants/learnDetail';
+import {
+  SCRIPT_MAX_COUNT,
+  VIDEO_STATE_CUED,
+  VIDEO_STATE_PAUSED,
+  VIDEO_STATE_PLAYING,
+} from '@src/constants/learnDetail';
 import { INITIAL, INITIAL_MEMO_STATE } from '@src/constants/learnDetail/memo';
 import { DELETE_SCRIPT_MODAL_TEXT, MEMO_MODAL_TEXT_TYPE, NEW_MEMO_MODAL_TEXT } from '@src/constants/learnDetail/modal';
 import { useBodyScrollLock, useClickOutside } from '@src/hooks/common';
@@ -42,7 +47,7 @@ function LearnDetail() {
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
   const [player, setPlayer] = useState<YT.Player | null>();
   const [videoState, setVideoState] = useState(INITIAL);
-  const [currentTime, setCurrentTime] = useState(0);
+  const [currentSentenceIndex, setCurrentSentenceIndex] = useState(0);
   const getLoginStatus = () => localStorage.getItem('token') ?? '';
   const [prevLink, setPrevLink] = useState('');
   const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -53,7 +58,6 @@ function LearnDetail() {
   const [isRecordSaved, setIsRecordSaved] = useState<boolean>(false);
   const learnRef = useRef<HTMLDivElement>(null);
   const contextMenuRef = useRef<HTMLDivElement>(null);
-
   const { lockScroll, unlockScroll } = useBodyScrollLock();
   const { data: similarVideoData, isLoading } = useGetSimilarVideoData(Number(detailId));
   const { data: videoData, refetch } = useGetVideoData(!!speechGuide, Number(detailId), clickedTitleIndex);
@@ -155,19 +159,23 @@ function LearnDetail() {
   }, [detailId]);
 
   useEffect(() => {
-    if (!player) return;
+    if (!videoData) return;
+    const { sentences } = videoData;
+    if (currentSentenceIndex >= sentences.length) {
+      setCurrentSentenceIndex(0);
+      return;
+    }
 
-    const interval =
-      player &&
-      setInterval(() => {
-        setCurrentTime(player.getCurrentTime());
-      }, 100);
+    const delay = (sentences[currentSentenceIndex].endTime - sentences[currentSentenceIndex].startTime) * 1000;
+    const timeoutId = setTimeout(() => {
+      videoState === VIDEO_STATE_PLAYING && setCurrentSentenceIndex((prev) => prev + 1);
+    }, delay);
 
     if (videoState === VIDEO_STATE_PAUSED || videoState === VIDEO_STATE_CUED) {
-      interval && clearInterval(interval);
+      timeoutId && clearTimeout(timeoutId);
     }
-    return () => interval && clearInterval(interval);
-  }, [player, videoState]);
+    return () => timeoutId && clearTimeout(timeoutId);
+  }, [currentSentenceIndex, videoData, videoState]);
 
   useClickOutside({
     isEnabled: isContextMenuOpen,
@@ -230,7 +238,7 @@ function LearnDetail() {
                 <article>
                   <div ref={learnRef}>
                     {!isEditing &&
-                      videoData.sentences.map(({ id, order, text, startTime, endTime }, i) => (
+                      videoData.sentences.map(({ id, order, text, startTime }, i) => (
                         <StScriptText
                           onContextMenu={(e) => {
                             e.preventDefault();
@@ -238,9 +246,12 @@ function LearnDetail() {
                             !speechGuide && handleRightClick(e, videoData.scriptId, order);
                           }}
                           key={id}
-                          onClick={() => player?.seekTo(startTime, true)}
+                          onClick={() => {
+                            player?.seekTo(startTime, true);
+                            setCurrentSentenceIndex(i);
+                          }}
                           underline={underlineMemo(text, memoList)}
-                          isActive={startTime <= currentTime && currentTime < endTime}>
+                          isActive={i === currentSentenceIndex}>
                           <div id={id.toString()} dangerouslySetInnerHTML={{ __html: text }}></div>
                         </StScriptText>
                       ))}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #232

## 📋 작업 내용
- [x] 유튜브 동영상 재생시 100ms마다 발생하는 렌더링 최적화

## 📌 PR Point
- 동영상 재생시 100ms마다 상태가 재설정되어 리렌더링이 발생하고 있었습니다. 문장이 바뀔 때만 리렌더링이 일어나도록 로직을 수정하였습니다. 
- 자세한 내용은 [블로그](https://heycoding.tistory.com/135)에 정리했습니다. 

## 📸 스크린샷
동영상을 재생하고 두 번째 문장 시작 지점까지 프로파일링한 결과입니다. 렌더링 횟수가 68번에서 4번으로 줄어든 것을 확인할 수 있습니다. 
|전|후|
|--|--|
|![image](https://github.com/DeliverBle/deliverble-frontend/assets/63948884/d722a818-7f4d-4409-833e-5f1e571e683d)|![image](https://github.com/DeliverBle/deliverble-frontend/assets/63948884/be659e41-237d-488d-87f8-4ad68c2937a5)|



