### PR TITLE
[learn_detail] 메모 수정·삭제 기능 관련 유닛 테스트

### DIFF
--- a/__tests__/learnDetail/ConfirmModal.test.tsx
+++ b/__tests__/learnDetail/ConfirmModal.test.tsx
@@ -1,16 +1,17 @@
 import { ConfirmModal } from '@src/components/learnDetail/modal';
-import { NEW_MEMO_MODAL_TEXT } from '@src/constants/learnDetail/modal';
+import { INITIAL_MEMO_STATE } from '@src/constants/learnDetail/memo';
+import { EDIT_MEMO_MODAL_TEXT, NEW_MEMO_MODAL_TEXT } from '@src/constants/learnDetail/modal';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-describe('메모 추가 확인 모달 오픈', () => {
-  const setup = async () => {
-    const setMemoState = jest.fn();
-    const setIsConfirmOpen = jest.fn();
-    const onTitleDelete = jest.fn();
-    const updateMemoList = jest.fn();
-    const cancelCreateMemo = jest.fn();
+const setMemoState = jest.fn();
+const setIsConfirmOpen = jest.fn();
+const onTitleDelete = jest.fn();
+const updateMemoList = jest.fn();
+const cancelCreateMemo = jest.fn();
 
+describe('메모 추가 확인 모달 오픈', () => {
+  const setup = () => {
     const { getByText } = render(
       <ConfirmModal
         confirmModalText={NEW_MEMO_MODAL_TEXT}
@@ -25,20 +26,54 @@ describe('메모 추가 확인 모달 오픈', () => {
     const leftButton = getByText(NEW_MEMO_MODAL_TEXT.leftButtonText);
     const rightButton = getByText(NEW_MEMO_MODAL_TEXT.rightButtonText);
 
-    return { setIsConfirmOpen, cancelCreateMemo, leftButton, rightButton };
+    return { leftButton, rightButton };
   };
 
   it('작성하기 버튼 클릭시 모달 클로즈', async () => {
-    const { setIsConfirmOpen, leftButton } = await setup();
+    const { leftButton } = setup();
 
     await userEvent.click(leftButton);
     expect(setIsConfirmOpen).toHaveBeenCalledWith(false);
   });
 
   it('취소 버튼 클릭시 메모 작성 취소', async () => {
-    const { cancelCreateMemo, rightButton } = await setup();
+    const { rightButton } = setup();
 
     await userEvent.click(rightButton);
     expect(cancelCreateMemo).toHaveBeenCalled();
+  });
+});
+
+describe('메모 수정 확인 모달 오픈', () => {
+  const setup = () => {
+    const { getByText } = render(
+      <ConfirmModal
+        confirmModalText={EDIT_MEMO_MODAL_TEXT}
+        setMemoState={setMemoState}
+        setIsConfirmOpen={setIsConfirmOpen}
+        onTitleDelete={onTitleDelete}
+        updateMemoList={updateMemoList}
+        cancelCreateMemo={cancelCreateMemo}
+      />,
+    );
+
+    const leftButton = getByText(EDIT_MEMO_MODAL_TEXT.leftButtonText);
+    const rightButton = getByText(EDIT_MEMO_MODAL_TEXT.rightButtonText);
+
+    return { leftButton, rightButton };
+  };
+
+  it('수정하기 버튼 클릭시 모달 클로즈', async () => {
+    const { leftButton } = setup();
+
+    await userEvent.click(leftButton);
+    expect(setIsConfirmOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('수정 취소 버튼 클릭시 메모 수정 취소', async () => {
+    const { rightButton } = setup();
+
+    await userEvent.click(rightButton);
+    expect(setMemoState).toHaveBeenCalledWith(INITIAL_MEMO_STATE);
   });
 });

--- a/__tests__/learnDetail/ConfirmModal.test.tsx
+++ b/__tests__/learnDetail/ConfirmModal.test.tsx
@@ -1,6 +1,6 @@
 import { ConfirmModal } from '@src/components/learnDetail/modal';
 import { INITIAL_MEMO_STATE } from '@src/constants/learnDetail/memo';
-import { EDIT_MEMO_MODAL_TEXT, NEW_MEMO_MODAL_TEXT } from '@src/constants/learnDetail/modal';
+import { DELETE_MEMO_MODAL_TEXT, EDIT_MEMO_MODAL_TEXT, NEW_MEMO_MODAL_TEXT } from '@src/constants/learnDetail/modal';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -75,5 +75,39 @@ describe('메모 수정 확인 모달 오픈', () => {
 
     await userEvent.click(rightButton);
     expect(setMemoState).toHaveBeenCalledWith(INITIAL_MEMO_STATE);
+  });
+});
+
+describe('메모 삭제 확인 모달 오픈', () => {
+  const setup = () => {
+    const { getByText } = render(
+      <ConfirmModal
+        confirmModalText={DELETE_MEMO_MODAL_TEXT}
+        setMemoState={setMemoState}
+        setIsConfirmOpen={setIsConfirmOpen}
+        onTitleDelete={onTitleDelete}
+        updateMemoList={updateMemoList}
+        cancelCreateMemo={cancelCreateMemo}
+      />,
+    );
+
+    const leftButton = getByText(DELETE_MEMO_MODAL_TEXT.leftButtonText);
+    const rightButton = getByText(DELETE_MEMO_MODAL_TEXT.rightButtonText);
+
+    return { leftButton, rightButton };
+  };
+
+  it('취소 버튼 클릭시 모달 클로즈', async () => {
+    const { leftButton } = setup();
+
+    await userEvent.click(leftButton);
+    expect(setIsConfirmOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('삭제하기 버튼 클릭시 메모 삭제', async () => {
+    const { rightButton } = setup();
+
+    await userEvent.click(rightButton);
+    expect(updateMemoList).toHaveBeenCalledWith('delete');
   });
 });

--- a/__tests__/learnDetail/MemoDropdown.test.tsx
+++ b/__tests__/learnDetail/MemoDropdown.test.tsx
@@ -1,0 +1,41 @@
+import { MemoDropdown } from '@src/components/learnDetail/memo';
+import { INITIAL } from '@src/constants/learnDetail/memo';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const memoData = {
+  id: 3,
+  order: 4,
+  startIndex: 0,
+  keyword: '시가총액',
+  content: '숨을 크게 들이마시고',
+  highlightId: '571.232.31',
+};
+const setMemoState = jest.fn();
+const onMemoModal = jest.fn();
+
+const setup = () => {
+  const { getByRole } = render(
+    <MemoDropdown memoData={memoData} setMemoState={setMemoState} onMemoModal={onMemoModal} />,
+  );
+
+  const editMemoButton = getByRole('button', { name: '메모 수정' });
+  const deleteMemoButton = getByRole('button', { name: '메모 삭제' });
+
+  return { editMemoButton, deleteMemoButton };
+};
+
+it('메모 수정 버튼 클릭', async () => {
+  const { editMemoButton } = setup();
+
+  await userEvent.click(editMemoButton);
+  expect(setMemoState).toHaveBeenCalled();
+});
+
+it('메모 삭제 버튼 클릭', async () => {
+  const { deleteMemoButton } = setup();
+
+  await userEvent.click(deleteMemoButton);
+  expect(setMemoState).toHaveBeenCalled();
+  expect(onMemoModal).toHaveBeenCalledWith('delete');
+});

--- a/__tests__/learnDetail/MemoForm.test.tsx
+++ b/__tests__/learnDetail/MemoForm.test.tsx
@@ -1,20 +1,22 @@
 import { MemoForm } from '@src/components/learnDetail/memo';
-import { INITIAL } from '@src/constants/learnDetail/memo';
+import { INITIAL_MEMO_STATE } from '@src/constants/learnDetail/memo';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+const memoData = { order: 4, startIndex: 0, keyword: '시가총액', content: '', highlightId: '571.232.31' };
+const memoState = INITIAL_MEMO_STATE;
+const onMemoModal = jest.fn();
+const setMemoState = jest.fn();
+const updateMemoList = jest.fn();
+
 describe('메모 추가', () => {
   const setup = () => {
-    const memoData = { order: 4, startIndex: 0, keyword: '시가총액', content: '', highlightId: '571.232.31' };
-    const memoState = { newMemoId: 0, editMemoId: INITIAL, deleteMemoId: INITIAL };
-    const onMemoModal = jest.fn();
-    const setMemoState = jest.fn();
-    const updateMemoList = jest.fn();
+    const newMemoState = { ...memoState, newMemoId: 0 };
 
     const { getByRole } = render(
       <MemoForm
         memoData={memoData}
-        memoState={memoState}
+        memoState={newMemoState}
         onMemoModal={onMemoModal}
         setMemoState={setMemoState}
         updateMemoList={updateMemoList}
@@ -25,11 +27,11 @@ describe('메모 추가', () => {
     const submitButton = getByRole('button', { name: '완료' });
     const cancelButton = getByRole('button', { name: '취소' });
 
-    return { updateMemoList, onMemoModal, memoTextarea, submitButton, cancelButton };
+    return { memoTextarea, submitButton, cancelButton };
   };
 
   it('메모 입력 후 작성 완료 버튼 클릭하여 메모 저장', async () => {
-    const { updateMemoList, memoTextarea, submitButton } = setup();
+    const { memoTextarea, submitButton } = setup();
 
     expect(submitButton).toBeDisabled();
     await userEvent.type(memoTextarea, '숨을 크게 들이마시고');
@@ -40,7 +42,7 @@ describe('메모 추가', () => {
   });
 
   it('메모 입력 후 외부 클릭시 메모 저장', async () => {
-    const { updateMemoList, memoTextarea, submitButton } = setup();
+    const { memoTextarea, submitButton } = setup();
 
     expect(submitButton).toBeDisabled();
     await userEvent.type(memoTextarea, '숨을 크게 들이마시고');
@@ -51,16 +53,108 @@ describe('메모 추가', () => {
   });
 
   it('메모 작성 취소 버튼 클릭시 모달 오픈', async () => {
-    const { onMemoModal, cancelButton } = setup();
+    const { cancelButton } = setup();
 
     await userEvent.click(cancelButton);
     expect(onMemoModal).toHaveBeenCalledWith('new');
   });
 
   it('메모 입력 없이 외부 클릭시 모달 오픈', async () => {
-    const { onMemoModal } = setup();
-
     await userEvent.click(document.body);
     expect(onMemoModal).toHaveBeenCalledWith('new');
+  });
+});
+
+describe('메모 수정', () => {
+  const setup = () => {
+    const newMemoData = { ...memoData, id: 3, content: '숨을 크게 들이마시고' };
+    const newMemoState = { ...memoState, editMemoId: 3 };
+
+    const { getByRole } = render(
+      <MemoForm
+        memoData={newMemoData}
+        memoState={newMemoState}
+        onMemoModal={onMemoModal}
+        setMemoState={setMemoState}
+        updateMemoList={updateMemoList}
+      />,
+    );
+
+    const memoTextarea = getByRole('textbox');
+    const submitButton = getByRole('button', { name: '완료' });
+    const cancelButton = getByRole('button', { name: '취소' });
+
+    return { memoTextarea, submitButton, cancelButton };
+  };
+
+  it('메모 수정 후 작성 완료 버튼 클릭하여 메모 저장', async () => {
+    const { memoTextarea, submitButton } = setup();
+
+    expect(memoTextarea.textContent).toBe('숨을 크게 들이마시고');
+    await userEvent.clear(memoTextarea);
+
+    await userEvent.type(memoTextarea, '숨을 짧게 들이마시고');
+    await userEvent.click(submitButton);
+    expect(updateMemoList).toHaveBeenCalledWith('edit', '숨을 짧게 들이마시고');
+  });
+
+  it('메모 수정 후 외부 클릭시 메모 저장', async () => {
+    const { memoTextarea } = setup();
+
+    expect(memoTextarea.textContent).toBe('숨을 크게 들이마시고');
+    await userEvent.clear(memoTextarea);
+
+    await userEvent.type(memoTextarea, '숨을 짧게 들이마시고');
+    await userEvent.click(document.body);
+    expect(updateMemoList).toHaveBeenCalledWith('edit', '숨을 짧게 들이마시고');
+  });
+
+  it('메모 수정 없이 작성 완료 버튼을 클릭하거나 외부 클릭시 메모 저장', async () => {
+    const { memoTextarea } = setup();
+
+    expect(memoTextarea.textContent).toBe('숨을 크게 들이마시고');
+
+    await userEvent.click(document.body);
+    expect(updateMemoList).toHaveBeenCalledWith('edit', '숨을 크게 들이마시고');
+  });
+
+  it('메모 수정 후 취소 버튼 클릭시 모달 오픈', async () => {
+    const { memoTextarea, cancelButton } = setup();
+
+    expect(memoTextarea.textContent).toBe('숨을 크게 들이마시고');
+    await userEvent.clear(memoTextarea);
+
+    await userEvent.type(memoTextarea, '숨을 짧게 들이마시고');
+    await userEvent.click(cancelButton);
+    expect(onMemoModal).toHaveBeenCalledWith('edit');
+  });
+
+  it('메모 수정 없이 취소 버튼 클릭시 메모 수정 취소', async () => {
+    const { memoTextarea, cancelButton } = setup();
+
+    expect(memoTextarea.textContent).toBe('숨을 크게 들이마시고');
+
+    await userEvent.click(cancelButton);
+    expect(setMemoState).toHaveBeenCalledWith(INITIAL_MEMO_STATE);
+  });
+
+  it('메모 전부 지우고 취소 버튼 클릭시 메모 수정 취소', async () => {
+    const { memoTextarea, cancelButton } = setup();
+
+    expect(memoTextarea.textContent).toBe('숨을 크게 들이마시고');
+    await userEvent.clear(memoTextarea);
+
+    await userEvent.click(cancelButton);
+    expect(setMemoState).toHaveBeenCalledWith(INITIAL_MEMO_STATE);
+  });
+
+  it('메모 전부 지우고 외부 클릭시 메모 수정 취소', async () => {
+    const { memoTextarea } = setup();
+
+    expect(memoTextarea.textContent).toBe('숨을 크게 들이마시고');
+    await userEvent.clear(memoTextarea);
+
+    await userEvent.click(document.body);
+    expect(setMemoState).toHaveBeenCalledWith(INITIAL_MEMO_STATE);
   });
 });

--- a/src/components/learnDetail/memo/MemoDropdown.tsx
+++ b/src/components/learnDetail/memo/MemoDropdown.tsx
@@ -26,10 +26,10 @@ function MemoDropdown(props: MemoDropdownProps) {
 
   return (
     <StMemoDropdown>
-      <button type="button" onClick={handleClickEdit}>
+      <button aria-label="메모 수정" type="button" onClick={handleClickEdit}>
         메모 수정
       </button>
-      <button type="button" onClick={handleClickDelete}>
+      <button aria-label="메모 삭제" type="button" onClick={handleClickDelete}>
         메모 삭제
       </button>
     </StMemoDropdown>


### PR DESCRIPTION
## 🚩 관련 이슈
- close #238 

## 📋 작업 내용
- [x] 메모 수정·삭제 관련 ConfirmModal 컴포넌트 유닛 테스트 작성
- [x] 메모 수정 관련 MemoForm 컴포넌트 유닛 테스트 작성
- [x] MemoDropdown 컴포넌트 유닛 테스트 작성

## 📌 PR Point
- 메모 수정 기능과 삭제 기능과 관련된 유닛 테스트를 작성하였습니다. 
- (이전 PR pull 받고 작업. https://github.com/DeliverBle/deliverble-frontend/pull/239/commits/6054d5f5a8bbd10247ce182898db87780f86d0c1 부터 보시면 됩니다.)

## 📸 스크린샷
<img width="416" alt="image" src="https://github.com/DeliverBle/deliverble-frontend/assets/63948884/600345f3-9e6c-4ff8-b5e9-6e3a006cb6db">
