### PR TITLE
[home] 홈 페이지 SSG with Data fetching

### DIFF
--- a/src/components/common/ProfileModal.tsx
+++ b/src/components/common/ProfileModal.tsx
@@ -11,8 +11,7 @@ import ImageDiv from '../common/ImageDiv';
 function ProfileModal() {
   const router = useRouter();
   const setIsLoggedIn = useSetRecoilState(loginState);
-  const accessToken = localStorage.getItem('token');
-  const { data } = useQuery(['userInfo'], () => api.commonService.getUserInfo(accessToken), {
+  const { data } = useQuery(['userInfo'], () => api.commonService.getUserInfo(), {
     onError: () => {
       console.error('유저 데이터 요청 에러 발생');
     },

--- a/src/components/landing/Header.tsx
+++ b/src/components/landing/Header.tsx
@@ -3,10 +3,12 @@ import { loginState } from '@src/stores/loginState';
 import { COLOR, FONT_STYLES } from '@src/styles';
 import dynamic from 'next/dynamic';
 import { icDeliverbleBlue, icDeliverbleWhite } from 'public/assets/icons';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 import ImageDiv from '../common/ImageDiv';
+
+const LoginModal = dynamic(() => import('@src/components/login/LoginModal'), { ssr: false });
 
 interface HeaderProps {
   isFirstScrolled?: boolean;
@@ -15,10 +17,14 @@ interface HeaderProps {
 
 function Header(props: HeaderProps) {
   const { isFirstScrolled = false, isSecondScrolled = false } = props;
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const isLoggedIn = useRecoilValue(loginState);
   const { lockScroll, unlockScroll } = useBodyScrollLock();
-  const LoginModal = dynamic(() => import('@src/components/login/LoginModal'), { ssr: false });
+  const loginValue = useRecoilValue(loginState);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    setIsLoggedIn(loginValue);
+  }, []);
 
   return (
     <>

--- a/src/services/api/common.ts
+++ b/src/services/api/common.ts
@@ -2,6 +2,6 @@ import { UserData, LikeData } from '@src/types/common/remote';
 
 export interface CommonService {
   requestLogin(code: string): Promise<string | undefined>;
-  getUserInfo(accessToken: string | null): Promise<UserData>;
+  getUserInfo(): Promise<UserData>;
   postLikeData(newsId: number): Promise<LikeData>;
 }

--- a/src/services/queries/home.ts
+++ b/src/services/queries/home.ts
@@ -1,15 +1,18 @@
 import { api } from '@src/services/api';
+import { VideoData } from '@src/types/home/remote';
 import { useQuery } from '@tanstack/react-query';
 
-export const useGetRecommendVideoList = () => {
+export const useGetRecommendVideoList = (initialRecommendNewsList: VideoData[]) => {
   return useQuery(['getRecommendVideoList'], () => api.homeService.getVideoData(), {
+    initialData: initialRecommendNewsList,
     cacheTime: Infinity,
     staleTime: Infinity,
   });
 };
 
-export const useGetSpeechGuideList = () => {
+export const useGetSpeechGuideList = (initialSpeechGuideList: VideoData[]) => {
   return useQuery(['getSpeechGuideList'], () => api.homeService.getSpeechGuideData(), {
+    initialData: initialSpeechGuideList,
     cacheTime: Infinity,
     staleTime: Infinity,
   });

--- a/src/services/remote/base.ts
+++ b/src/services/remote/base.ts
@@ -2,7 +2,13 @@ import { BASE_URL, STATUS_CODE } from '@src/constants/common';
 import { BadRequestError, ForbiddenError, InternalServerError, UnauthorizedError } from '@src/types/error';
 import axios, { AxiosError, AxiosResponse } from 'axios';
 
-const getAccessToken = () => localStorage.getItem('token') ?? '';
+export const getAccessToken = () => {
+  let accessToken = '';
+  if (typeof window !== 'undefined') {
+    accessToken = localStorage.getItem('token') ?? '';
+  }
+  return accessToken;
+};
 
 const getBaseHeaders = () => {
   const accessToken = getAccessToken();

--- a/src/services/remote/common.ts
+++ b/src/services/remote/common.ts
@@ -13,18 +13,10 @@ export function commonDataRemote(): CommonService {
     }
   };
 
-  const getUserInfo = async (accessToken: string | null) => {
-    try {
-      const response = await axios.get(`${BASE_URL}/user`, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-      });
-      return {
-        nickname: response.data.data.nickname,
-        email: response.data.data.email,
-      };
-    } catch {
-      throw '유저 데이터 요청 에러 발생';
-    }
+  const getUserInfo = async () => {
+    const response = await API.get({ url: `/user` });
+    const { nickname, email } = response.data;
+    return { nickname, email };
   };
 
   const postLikeData = async (newsId: number) => {

--- a/src/types/home/index.ts
+++ b/src/types/home/index.ts
@@ -1,0 +1,6 @@
+import { VideoData } from '@src/types/home/remote';
+
+export type NewsListType = {
+  initialRecommendNewsList: VideoData[];
+  initialSpeechGuideList: VideoData[];
+};


### PR DESCRIPTION
## 🚩 관련 이슈
- close #247 

## 📋 작업 내용
- [x]  홈 페이지 getStaticProps에서 데이터 fetching

## 📌 PR Point
- 홈 페이지에 있는 데이터는 스피치 가이드 목록과 추천 뉴스 목록입니다.
다만, 이 데이터들은 로그인하지 않으면 좋아요를 누를 수 없으므로 항상 정적인 상태로 유지됩니다.
따라서 `getStaticProps`를 이용하여 데이터를 불러오고 페이지의 `props`로 보내 `useQuery`의 `initialData`로 주면 스켈레톤 UI를 보여줄 필요가 없게 됩니다.
- 로그인이 되어 있거나, 로그인을 한다면 useQuery의 refetch를 통해 로그인한 유저의 데이터를 새롭게 불러옵니다.

## 📸 스크린샷
|변경 전|변경 후|
|--|--|
|![화면 기록 2023-08-11 오후 4 25 48](https://github.com/DeliverBle/deliverble-frontend/assets/63948884/5f0e601b-403c-49d1-b048-8702e8707aaf)|![화면 기록 2023-08-11 오후 4 26 15](https://github.com/DeliverBle/deliverble-frontend/assets/63948884/8446c4cf-6969-48e0-aaaa-6c3c79a1a0b9)|




